### PR TITLE
Fix shift modifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
     "url": "https://github.com/scottlogic/finput.git"
   },
   "bugs": "https://github.com/scottlogic/finput/issues",
-  "dependencies": {
-    "keycode": "^2.1.0"
-  },
+  "dependencies": {},
   "main": "./lib/finput.js",
   "devDependencies": {
     "babel-plugin-add-module-exports": "^0.1.2",

--- a/src/finput.js
+++ b/src/finput.js
@@ -343,7 +343,7 @@ class Finput {
         // If ctrl key modifier is pressed then allow specific event handler
         // to handle this
         if (!e.ctrlKey) {
-          this.options.invalidKeyCallback(createInvalidKeyInfo(keyInfo));
+          this.options.invalidKeyCallback(this.createInvalidKeyInfo(keyInfo));
           e.preventDefault();
         }
         return;

--- a/src/finput.js
+++ b/src/finput.js
@@ -126,11 +126,11 @@ class Finput {
       },
       {
         type: ACTION_TYPES.HORIZONTAL_ARROW,
-        names: ['left', 'right']
+        names: ['arrowleft', 'arrowright']
       },
       {
         type: ACTION_TYPES.VERTICAL_ARROW,
-        names: ['up', 'down']
+        names: ['arrowup', 'arrowdown']
       },
       {
         type: ACTION_TYPES.UNDO,
@@ -295,7 +295,7 @@ class Finput {
     const keyInfo = {
       event: e,
       code: e.which || e.keyCode,
-      keyName: keycode(e) ? keycode(e).replace('numpad ', '') : null,
+      keyName: e.key.toLowerCase(),
       caretStart: this.element.selectionStart,
       caretEnd: this.element.selectionEnd,
       currentValue: this.element.value,

--- a/src/finput.js
+++ b/src/finput.js
@@ -1,4 +1,3 @@
-import keycode from 'keycode';
 import keyHandlers from './keyHandlers';
 import helpers from './helpers';
 import ValueHistory from './valueHistory';


### PR DESCRIPTION
When a keydown event is raised for `shift+3` we get something like:
```
{
  key: "£",
  code: "51" // this represents '3' and is therefore incorrect
}
```

When `keycode` parses the event it interprets this as "3" instead of "£". This results in us editing the element's value with "3" instead of correctly ignoring the key press. I'm guessing `keycode` is looking exclusively at `code` to return a key name (although I haven't checked their code). I don't think this is a bug in their lib as they're correctly interpreting the code. The event itself seems to have `key` and `code` that are inconsistent.

[The docs](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) state that keydown should not be used with `keyCode` and that keypress is better (I tested this and we get the correct code for "£" but `keycode` still fails to correctly interpret this for some reason). Also we can't use that as keypress only triggers for printable chars, but we want to handle unprintable keys like "Delete" etc. We could possibly listen to both events; keydown for special keys and keypress for regular keys, but this seemed to be adding complexity.

[Firefox docs ](https://developer.mozilla.org/en-US/docs/Web/Events/keydown) state that `event.key` is unimplemented in Firefox, but I tested use of `event.key` on macOS Chrome and Firefox and both work (we probably need to check these changes on Windows too). I also tested with all action types which revealed that `key` is sometimes different to `keycode`'s returned values, but we handle this by changing our action type names.

There may be some other good reasons that we're using `keycode` that I am not aware of, so please let me know if I've missed something.