### PR TITLE
Add setOptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,11 @@
                 <label for="finput-reversed-delimiters">Reversed Delimiters</label>
                 <input type="text" id="finput-reversed-delimiters" class="form-control">
             </div>
+            <div class="form-group">
+                <label for="finput-switch-options">Switch Options</label>
+                <input type="text" id="finput-switch-options" class="form-control">
+                <button type="button" id="finput-switch-options-button">Switch Options</button>
+            </div>
         </form>
 
         <h2>Native Controls</h2>
@@ -57,6 +62,8 @@
       var finputCustomFocus = document.getElementById('finput-custom-focus');
       var finputInvalidKeyCallback = document.getElementById('finput-invalid-key-callback');
       var finputReversedDelimiters = document.getElementById('finput-reversed-delimiters');
+      var finputSwitchOptions = document.getElementById('finput-switch-options');
+      var finputSwitchOptionsButton = document.getElementById('finput-switch-options-button');
 
       finput(finputDefault, {});
 
@@ -72,5 +79,18 @@
           thousands: '.',
           decimal: ','
       });
+
+      finput(finputSwitchOptions, {});
+
+      finputSwitchOptionsButton.onclick = function () {
+          var options = finputSwitchOptions.getOptions();
+          var tempThousands = options.thousands;
+          options.thousands = options.decimal;
+          options.decimal = tempThousands;
+
+          finputSwitchOptions.setOptions(options);
+          // redraw
+          finputSwitchOptions.setRawValue(finputSwitchOptions.rawValue);
+      }
   </script>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2962,6 +2962,11 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
+    "is_js": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/is_js/-/is_js-0.9.0.tgz",
+      "integrity": "sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0="
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "url": "https://github.com/scottlogic/finput.git"
   },
   "bugs": "https://github.com/scottlogic/finput/issues",
-  "dependencies": {},
+  "dependencies": {
+    "is_js": "^0.9.0"
+  },
   "main": "./lib/finput.js",
   "devDependencies": {
     "babel-plugin-add-module-exports": "^0.1.2",

--- a/readme.md
+++ b/readme.md
@@ -116,8 +116,27 @@ input once again.
 API
 --------------------
 
-The following functions are exposed on the `element` for direct, controlled manipulation of the input value.
+The following functions are exposed on the `element`:
 
+##### getOptions
+Gets a copy of the options from the input
+
+##### setOptions
+Sets the options on the input
+* `options` New options to set. Copied before being set.
+
+Note that `setOptions` supplements the current options rather than replacing. 
+```
+element.setOptions({ thousands: '.' });
+element.setOptions({ decimal: ',' });
+```
+The above therefore results in the following `options`:
+```
+{
+  thousands: '.',
+  decimal: ','
+} 
+```
 ##### setValue
 Sets the value, fully formatted, for the input
  * `val` New value to set

--- a/src/finput.js
+++ b/src/finput.js
@@ -169,10 +169,10 @@ class Finput {
 
   /**
    * Get numerical value of the given value
-   * @param {val} Value to convert
+   * @param {value} Value to convert
    */
-  getRawValue() {
-    return Number(this.element.value.replace(new RegExp(this.options.thousands, 'g'), ''));
+  getRawValue(value) {
+    return helpers.toNumber(value, this.options);
   }
 
 
@@ -200,7 +200,7 @@ class Finput {
     if (!val) {
       value = '';
     } else if (typeof val === 'number' && !isNaN(val)) {
-      value = val.toString();
+      value = helpers.toString(val, this.options);
     } else if (typeof val === 'string') {
       value = val;
     } else {

--- a/src/finput.js
+++ b/src/finput.js
@@ -74,8 +74,17 @@ class Finput {
   get element() {
     return this._element;
   }
+
   get options() {
-    return this._options;
+    return {
+      ...this._options
+    };
+  }
+  set options(options) {
+    this._options = {
+      ...this._options,
+      ...options
+    };
   }
 
   /**
@@ -377,10 +386,14 @@ export default function(element, options) {
   const input = new Finput(element, options || {});
   element.setRawValue = (v) => input.setRawValue(v);
   element.setValue = (v) => input.setValue(v);
+  element.getOptions = () => input.options;
+  element.setOptions = (o) => input.options = o;
 
   return () => {
     input.removeListeners();
     delete element.setRawValue;
     delete element.setValue;
+    delete element.getOptions;
+    delete element.setOptions;
   }
 };

--- a/src/finput.js
+++ b/src/finput.js
@@ -172,7 +172,7 @@ class Finput {
    * @param {value} Value to convert
    */
   getRawValue(value) {
-    return helpers.toNumber(value, this.options);
+    return helpers.formattedToRaw(value, this.options);
   }
 
 
@@ -200,7 +200,7 @@ class Finput {
     if (!val) {
       value = '';
     } else if (typeof val === 'number' && !isNaN(val)) {
-      value = helpers.toString(val, this.options);
+      value = helpers.rawToFormatted(val, this.options);
     } else if (typeof val === 'string') {
       value = val;
     } else {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -191,11 +191,11 @@ exports.formattedToRaw = function(formattedValue, options) {
 
   // 1. Remove thousands delimiter to cover case it is not ','
   // Cannot replace with ',' in case decimal uses this
-  formattedValue = formattedValue.replace(new RegExp(`[${options.thousands}]`, 'g'), '')
+  formattedValue = formattedValue.replace(new RegExp(`[${options.thousands}]`, 'g'), '');
   
   // 2. Replace decimal with '.' to cover case it is not '.'
   // Ok to replace as thousands delimiter removed above
-  formattedValue = formattedValue.replace(new RegExp(`[${options.decimal}]`, 'g'), '.')
+  formattedValue = formattedValue.replace(new RegExp(`[${options.decimal}]`, 'g'), '.');
   return Number(formattedValue);
 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,6 @@
 
 import {ACTION_TYPES, DRAG_STATES} from './constants';
+import is from 'is_js';
 
 function getDecimalIndex(val, decimal) {
   return val.indexOf(decimal) > -1
@@ -183,24 +184,25 @@ exports.allowedZero = function(val, char, caretPos, options) {
  * @param {val} string value to convert to a number
  * @param {options} Finput options object
  */
-exports.toNumber = function(stringValue, options) {
-  if (!stringValue) return null;
+exports.formattedToRaw = function(formattedValue, options) {
+  if (is.not.string(formattedValue)) return NaN;
 
   // Number(...) accepts thousands ',' or '' and decimal '.' so we must:
 
   // 1. Remove thousands delimiter to cover case it is not ','
   // Cannot replace with ',' in case decimal uses this
-  stringValue = stringValue.replace(new RegExp(`[${options.thousands}]`, 'g'), '')
+  formattedValue = formattedValue.replace(new RegExp(`[${options.thousands}]`, 'g'), '')
   
   // 2. Replace decimal with '.' to cover case it is not '.'
   // Ok to replace as thousands delimiter removed above
-  stringValue = stringValue.replace(new RegExp(`[${options.decimal}]`, 'g'), '.')
-  return Number(stringValue);
+  formattedValue = formattedValue.replace(new RegExp(`[${options.decimal}]`, 'g'), '.')
+  return Number(formattedValue);
 }
 
-exports.toString = function (numberValue, options) {
-  if (!numberValue) return null;
-  let stringValue = String(numberValue);
+exports.rawToFormatted = function (rawValue, options) {
+  if (is.not.number(rawValue)) return '';
+
+  let stringValue = String(rawValue);
 
   // String(...) has normalised formatting of:
   const rawThousands = ',';
@@ -241,9 +243,9 @@ exports.parseString = function(str, options) {
   if (!parsed.length) { return '' }
 
   // Need to ensure that delimiter is a '.' before parsing to number
-  const normalisedNumber = this.toNumber(parsed, options);
+  const normalisedNumber = this.formattedToRaw(parsed, options);
   // Then swap it back in
-  const adjusted = this.toString(normalisedNumber * multiplier, options);
+  const adjusted = this.rawToFormatted(normalisedNumber * multiplier, options);
   const tooLarge = adjusted.indexOf('e') !== -1;
 
   if (tooLarge) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -183,8 +183,34 @@ exports.allowedZero = function(val, char, caretPos, options) {
  * @param {val} string value to convert to a number
  * @param {options} Finput options object
  */
-exports.toNumber = function(val, options) {
-  return val && Number(val.replace(new RegExp(`[${options.thousands}]`, 'g'), ''));
+exports.toNumber = function(stringValue, options) {
+  if (!stringValue) return null;
+
+  // Number(...) accepts thousands ',' or '' and decimal '.' so we must:
+
+  // 1. Remove thousands delimiter to cover case it is not ','
+  // Cannot replace with ',' in case decimal uses this
+  stringValue = stringValue.replace(new RegExp(`[${options.thousands}]`, 'g'), '')
+  
+  // 2. Replace decimal with '.' to cover case it is not '.'
+  // Ok to replace as thousands delimiter removed above
+  stringValue = stringValue.replace(new RegExp(`[${options.decimal}]`, 'g'), '.')
+  return Number(stringValue);
+}
+
+exports.toString = function (numberValue, options) {
+  if (!numberValue) return null;
+  let stringValue = String(numberValue);
+
+  // String(...) has normalised formatting of:
+  const rawThousands = ',';
+  const rawDecimal = '.';
+
+  // ensure string we are returning adheres to options
+  stringValue = stringValue.replace(new RegExp(`[${rawThousands}]`, 'g'), options.thousands);
+  stringValue = stringValue.replace(new RegExp(`[${rawDecimal}]`, 'g'), options.decimal);
+
+  return stringValue;
 }
 
 exports.parseString = function(str, options) {
@@ -215,9 +241,9 @@ exports.parseString = function(str, options) {
   if (!parsed.length) { return '' }
 
   // Need to ensure that delimiter is a '.' before parsing to number
-  const normalisedNumber = Number(parsed.replace(new RegExp(`[${options.decimal}]`, 'g'), '.'));
+  const normalisedNumber = this.toNumber(parsed, options);
   // Then swap it back in
-  const adjusted = String(normalisedNumber * multiplier).replace(new RegExp(`[\.]`, 'g'), options.decimal);
+  const adjusted = this.toString(normalisedNumber * multiplier, options);
   const tooLarge = adjusted.indexOf('e') !== -1;
 
   if (tooLarge) {

--- a/src/keyHandlers.js
+++ b/src/keyHandlers.js
@@ -107,7 +107,7 @@ module.exports = {
   onShortcut: function (currentState, keyInfo, options) {
     const multiplier = options.shortcuts[keyInfo.keyName] || 1;
     const adjustedVal = helpers.editString(currentState.value, '', currentState.caretStart, currentState.caretEnd);
-    const rawValue = (helpers.toNumber(adjustedVal, options) || 1) * multiplier;
+    const rawValue = (helpers.formattedToRaw(adjustedVal, options) || 1) * multiplier;
 
     const newState = { ...currentState };    
     if (multiplier) {


### PR DESCRIPTION
Using `setRawValue` to redraw the finput element when switching options revealed a couple of issues with thousands/decimal delimiters which is also fixed in this PR.