### PR TITLE
chore: Add lib build (distinct from dist build)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ selenium-debug.log
 tests/nightwatch/report
 config.json
 dist/
+lib/
 
 # macOS
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -215,6 +215,12 @@
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
+    "babel-cli": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.1.tgz",
+      "integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM=",
+      "dev": true
+    },
     "babel-code-frame": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
@@ -595,6 +601,12 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "dev": true
+    },
+    "babel-polyfill": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
+      "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
       "dev": true
     },
     "babel-preset-es2015": {
@@ -1066,9 +1078,9 @@
       "dev": true
     },
     "crypto-browserify": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
-      "integrity": "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI=",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+      "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
       "dev": true
     },
     "cssom": {
@@ -1441,6 +1453,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/from2-string/-/from2-string-1.1.0.tgz",
       "integrity": "sha1-GCgrJ9CKJnyzAwzSuLSw8hKvdSo=",
+      "dev": true
+    },
+    "fs-readdir-recursive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
+      "integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
       "dev": true
     },
     "fs.realpath": {
@@ -3366,6 +3384,20 @@
       "integrity": "sha1-UM+GFjZeh+Ax4ppeyTOaPaRyX6I=",
       "dev": true
     },
+    "output-file-sync": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        }
+      }
+    },
     "over": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
@@ -4461,6 +4493,12 @@
       "integrity": "sha1-QAV+LxZLiOXaynJp2kfm0d2Detw=",
       "dev": true
     },
+    "user-home": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+      "dev": true
+    },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
@@ -4485,6 +4523,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
       "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "dev": true
+    },
+    "v8flags": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "dev": true
     },
     "validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
   "dependencies": {
     "is_js": "^0.9.0"
   },
-  "main": "./dist/finput.js",
+  "main": "./lib/finput.js",
   "devDependencies": {
+    "babel-cli": "^6.24.1",
     "babel-plugin-add-module-exports": "^0.1.2",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-stage-2": "^6.5.0",
@@ -26,17 +27,18 @@
     "browserstacktunnel-wrapper": "^1.4.2",
     "budo": "^10.0.3",
     "jasmine": "^2.4.1",
+    "jest": "^20.0.4",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.6.1",
-    "uglify-js": "^3.0.24",
-    "jest": "^20.0.4",
     "selenium-webdriver": "^3.4.0",
+    "uglify-js": "^3.0.24",
     "webdriver-manager": "^12.0.6"
   },
   "scripts": {
-    "clean": "rimraf ./dist && mkdirp ./dist/",
-    "compile": "browserify -d ./src/finput.js -s finput -o ./dist/finput.js -t babelify && uglifyjs ./dist/finput.js -o ./dist/finput.min.js",
-    "build": "npm run clean && npm run compile",
+    "clean": "rimraf ./dist && rimraf ./lib && mkdirp ./dist/ && mkdirp ./lib/",
+    "build:dist": "browserify -d ./src/finput.js -s finput -o ./dist/finput.js -t babelify && uglifyjs ./dist/finput.js -o ./dist/finput.min.js",
+    "build:lib": "babel ./src -d ./lib",
+    "build": "npm run clean && npm run build:dist && npm run build:lib",
     "start": "budo -l -o -p 3000 src/finput.js:dist/finput.js -- -s finput -t babelify",
     "webdriver": "webdriver-manager",
     "postinstall": "webdriver-manager update",


### PR DESCRIPTION
dist:
For use in html script tags. Including this script makes a global finput
object available. This is a bundle that includes all of finput and its
dependencies.

lib:
For use in npm package imports/requires. This is **not** a bundle and
includes all of finput's transpiled source files so that they work in
a node environment. The idea is that anyone installing and requiring
finput will then use a bundler on their entry file which will bundle
finput in with the rest of their dependencies.