### PR TITLE
chore: github page serves finput bundle working in browser environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lodash": "^4.17.4"
   },
   "main": "./lib/finput.js",
+  "unpkg": "./dist/finput.min.js",
   "types": "./finput.d.ts",
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
Commit f60e71015e6f8cf8df538cd3dee0b69cae0c10be made dist and lib builds distincts.
- lib build for npm package installs
- dist build for browser environments
lib build was published to npm as specified in package.json "main" field,
but was also served by unpkg in the abscense of "unpkg" field.
Adding the "unpkg" field pointing to the dist build allows unpkg to serve
the dist file which supports browser environment.

Closes #110