### PR TITLE
chore: refactor specs to make it functions and expectations explicit

### DIFF
--- a/test/customCommands.js
+++ b/test/customCommands.js
@@ -1,178 +1,177 @@
 import {Key, WebElement} from 'selenium-webdriver';
-import {nativeText, finputSwitchOptionsButton} from './pageObjects/index';
 import {isMac, isChrome, getModifierKey, driver} from './helpers';
+import { getDriver, load, unload } from './pageObjects/index';
 import {mapKeys} from './keys';
 
-const shouldSkipModifierKeyTest = async () => {
-  const mac = await isMac();
-  const chrome = await isChrome();
+const shouldSkipModifierKeyTest = async (driver) => {
+  const mac = await isMac(driver);
+  const chrome = await isChrome(driver);
   return mac && chrome;
 };
 
-export default (finputElement) => {
-  const typing = (keys) => {
-    let blurAfter = false;
-    let pressModifier = false;
-    let switchDelimiter = false;
+export const copyingAndPasting = ({ driver, finputElement, nativeText }) => 
+  async ({ tested, expected }) => {
 
-    const chainFunctions = {};
+    if (await shouldSkipModifierKeyTest(driver)) {
+      console.warn(`Skipping test as Command key fails on Chrome/Mac. Note that this will show as a passing test. Test: '${testName}'`)
+      return;
+    }
+    const modifierKey = await getModifierKey(driver);
 
+    await nativeText().clear();
+    await nativeText().click();
+    await nativeText().sendKeys(tested);
+    await nativeText().sendKeys(Key.chord(modifierKey, 'a'));
+    await nativeText().sendKeys(Key.chord(modifierKey, 'c'));
+    await nativeText().clear();
+    
+    await finputElement().clear();
+    await finputElement().click();
+    await finputElement().sendKeys(Key.chord(modifierKey, 'v'));
 
-    chainFunctions.thenSwitchingDelimiters = () => {
-      switchDelimiter = true;
-      return chainFunctions;
-    };
-
-    chainFunctions.thenBlurring = () => {
-      blurAfter = true;
-      return chainFunctions;
-    };
-
-    chainFunctions.whileModifierPressed = () => {
-      pressModifier = true;
-      return chainFunctions;
-    };
-
-    chainFunctions.shouldShow = (expected) => {
-      const withModifierMsg = pressModifier ? "with modifier key" : "";
-      const testName = `should show "${expected}" when "${keys}" ${keys.length === 1 ? 'is' : 'are' } pressed ${withModifierMsg}`;
-
-      it(testName, async () => {
-        await finputElement().clear();
-        await finputElement().click();
-
-        if (pressModifier) {
-          const mac = await isMac();
-          const chrome = await isChrome();
-
-          if (mac && chrome) {
-            console.warn(`Skipping test as Command key fails on Chrome/Mac. Note that this will show as a passing test. Test: '${testName}'`);
-            return;
-          }
-
-          const modifierKey = await getModifierKey();
-          await finputElement().sendKeys(Key.chord(modifierKey, mapKeys(keys)));
-        } else {
-          await finputElement().sendKeys(mapKeys(keys));
-        }
-
-        if (switchDelimiter) {
-          await finputSwitchOptionsButton().click();
-        }
-
-        if (blurAfter) {
-          await nativeText().click();
-        }
-
-        const observed = await finputElement().getAttribute('value');
-        expect(observed).toBe(expected);
-      });
-
-      return chainFunctions;
-    };
-
-    chainFunctions.shouldHaveFocus = (expected) => {
-      it(`should have focus: ` + expected, async () => {
-        const element = await finputElement();
-        const activeElement = await driver.switchTo().activeElement();
-        const observed = await WebElement.equals(element, activeElement);
-        expect(observed).toBe(expected);
-      });
-
-      return chainFunctions;
-    };
-
-    chainFunctions.shouldHaveCaretAt = (expected) => {
-      it('should have caret at index: ' + expected, async () => {
-        const selection = await driver.executeScript(() => {
-          return [document.activeElement.selectionStart, document.activeElement.selectionEnd];
-        });
-
-        expect(selection[0]).toEqual(selection[1]); // no selection, only caret cursor
-        expect(selection[0]).toEqual(expected);
-      });
-
-      return chainFunctions;
-    };
-
-    return chainFunctions;
+    const observed = await finputElement().getAttribute('value');
+    expect(observed).toBe(expected);
   };
 
-  const copyingAndPasting = (text) => {
-    const chainFunctions = {};
+export const cutting = ({ driver, finputElement }) => 
+  async ({ cut, startingFrom, tested, expected }) => {
 
-    chainFunctions.shouldShow = (expected) => {
-      const testName = `should show "${expected}" when "${text}" is copied and pasted`;
-      it(testName, async () => {
-        if (await shouldSkipModifierKeyTest()) {
-          console.warn(`Skipping test as Command key fails on Chrome/Mac. Note that this will show as a passing test. Test: '${testName}'`)
-          return;
-        }
-        const modifierKey = await getModifierKey();
+    if (await shouldSkipModifierKeyTest(driver)) {
+      console.warn(`Skipping test as Command key fails on Chrome/Mac. Note that this will show as a passing test. Test: '${testName}'`)
+      return;
+    }
+    const modifierKey = await getModifierKey(driver);
 
-        await nativeText().clear();
-        await nativeText().click();
-        await nativeText().sendKeys(text);
-        await nativeText().sendKeys(Key.chord(modifierKey, 'a'));
-        await nativeText().sendKeys(Key.chord(modifierKey, 'c'));
-        await nativeText().clear();
+    await finputElement().clear();
+    await finputElement().click();
+    await finputElement().sendKeys(tested);
+    await finputElement().sendKeys(Key.chord(modifierKey, 'a'));
+    await finputElement().sendKeys(mapKeys('←'));
+    await finputElement().sendKeys(Array(startingFrom + 1).join(mapKeys('→')));
+    await finputElement().sendKeys(Key.chord(Key.SHIFT, Array(cut + 1).join(mapKeys('→'))));
+    await finputElement().sendKeys(Key.chord(modifierKey, 'x'));
 
-        await finputElement().clear();
-        await finputElement().click();
-        await finputElement().sendKeys(Key.chord(modifierKey, 'v'));
-
-        const observed = await finputElement().getAttribute('value');
-        expect(observed).toBe(expected);
-      });
-
-      return chainFunctions;
-    };
-
-    return chainFunctions;
+    const observed = await finputElement().getAttribute('value');
+    expect(observed).toBe(expected);
   };
 
-  const cutting = (count) => {
-    let text, startPos;
-    const chainFunctions = {};
+export const typing = ({ 
+  driver, 
+  finputElement, 
+  finputSwitchOptionsButton, 
+  nativeText 
+}) => 
+  async ({ 
+    blurAfter = false,
+    pressModifier = false,
+    switchDelimiter = false,
+    tested, 
+    expected,
+    expectedCaret,
+    expectedFocus
+  }) => {
 
-    chainFunctions.characters = () => chainFunctions;
+    await finputElement().clear();
+    await finputElement().click();
 
-    chainFunctions.from = (t) => {
-      text = t;
-      return chainFunctions;
-    };
+    if (pressModifier) {
+      const mac = await isMac(driver);
+      const chrome = await isChrome(driver);
 
-    chainFunctions.startingFrom = (start) => {
-      startPos = start;
-      return chainFunctions;
-    };
+      if (mac && chrome) {
+        console.warn(`Skipping test as Command key fails on Chrome/Mac. Note that this will show as a passing test. Test: '${testName}'`);
+        return;
+      }
 
-    chainFunctions.shouldShow = (expected) => {
-      const testName = `should show "${expected}" when "${text}" has chars cut`;
-      it(testName, async () => {
-        if (await shouldSkipModifierKeyTest()) {
-          console.warn(`Skipping test as Command key fails on Chrome/Mac. Note that this will show as a passing test. Test: '${testName}'`)
-          return;
-        }
-        const modifierKey = await getModifierKey();
+      const modifierKey = await getModifierKey(driver);
+      await finputElement().sendKeys(Key.chord(modifierKey, mapKeys(tested)));
+    } else {
+      await finputElement().sendKeys(mapKeys(tested));
+    }
 
-        await finputElement().clear();
-        await finputElement().click();
-        await finputElement().sendKeys(text);
-        await finputElement().sendKeys(Key.chord(modifierKey, 'a'));
-        await finputElement().sendKeys(mapKeys('←'));
-        await finputElement().sendKeys(Array(startPos + 1).join(mapKeys('→')));
-        await finputElement().sendKeys(Key.chord(Key.SHIFT, Array(count + 1).join(mapKeys('→'))));
-        await finputElement().sendKeys(Key.chord(modifierKey, 'x'));
+    if (switchDelimiter) {
+      await finputSwitchOptionsButton().click();
+    }
 
-        const observed = await finputElement().getAttribute('value');
-        expect(observed).toBe(expected);
+    if (blurAfter) {
+      await nativeText().click();
+    }
+
+    const observed = await finputElement().getAttribute('value');
+    expect(observed).toBe(expected);
+
+    if (expectedCaret !== undefined) {
+      const selection = await driver.executeScript(() => {
+        return [document.activeElement.selectionStart, document.activeElement.selectionEnd];
       });
-      return chainFunctions;
-    };
 
-    return chainFunctions;
+      expect(selection[0]).toEqual(selection[1]); // no selection, only caret cursor
+      expect(selection[0]).toEqual(expectedCaret);
+    }
+
+    if (expectedFocus !== undefined) {
+      const element = await finputElement();
+      const activeElement = await driver.switchTo().activeElement();
+      const observedFocus = await WebElement.equals(element, activeElement);
+      expect(observedFocus).toBe(expectedFocus);
+    }
   };
 
-  return {typing, copyingAndPasting, cutting};
+export const itCopyingAndPasting = ({ tested, expected }) => {
+  it(`should show "${expected}" when "${tested}" is copied and pasted`, 
+    async () => await itCopyingAndPasting.expectCopyingAndPasting({ 
+      tested, 
+      expected 
+    }));
 };
+
+export const itCutting = ({ 
+  cut, 
+  startingFrom, 
+  tested,
+  expected
+}) => {
+  it(
+    `should show "${expected} when "${tested}" ` +
+    `has ${cut} chars cut starting from ${startingFrom}`, 
+    async () => await itCutting.expectCutting({ 
+      cut, 
+      startingFrom, 
+      tested,
+      expected
+    }));
+};
+
+export const itTyping = ({ 
+  blurAfter,
+  pressModifier,
+  switchDelimiter,
+  tested, 
+  expected,
+  expectedCaret,
+  expectedFocus
+}) => {
+  it(
+    `should show "${expected}"` +
+    ` when "${tested}" ${tested.length === 1 ? 'is' : 'are'} pressed` +
+    `${pressModifier ? " with modifier key" : ""}` + 
+    `${expectedCaret !== undefined ? (" should have caret at index: " + expectedCaret) : ""}` +
+    `${expectedFocus !== undefined ? (" should have focus: " + expectedFocus): ""}`,
+    async () => await itTyping.expectTyping({
+      blurAfter,
+      pressModifier,
+      switchDelimiter,
+      tested, 
+      expected,
+      expectedCaret,
+      expectedFocus        
+    }));
+};
+
+/*
+  const withModifierMsg = pressModifier ? "with modifier key" : "";
+  const testName = `should show "${expected}" when "${keys}" ${keys.length === 1 ? 'is' : 'are' } pressed ${withModifierMsg}`;
+
+  'should have caret at index: ' + expected
+  `should have focus: ` + expected
+  */

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -14,29 +14,29 @@ const getSeleniumURL = () => {
   return 'http://localhost:4444/wd/hub'
 };
 
-
-
-export const driver = new Builder()
+const driver = new Builder()
   .withCapabilities(capabilities)
   .usingServer(getSeleniumURL())
   .build();
 
-export const isMac = async () => {
+export const getDriver = () => driver;
+
+export const isMac = async (driver) => {
   const capabilities = await driver.getCapabilities();
   const os = capabilities.get(Capability.PLATFORM);
   return os.toUpperCase().indexOf(Platform.MAC) >= 0;
 };
 
-export const isBrowser = async (browserName) => {
+export const isBrowser = (driver) => async (browserName) => {
   const capabilities = await driver.getCapabilities();
   const browser = capabilities.get(Capability.BROWSER_NAME);
   return browser.indexOf(browserName) >= 0;
 };
 
-export const isChrome = async () => isBrowser(Browser.CHROME);
+export const isChrome = async (driver) => isBrowser(driver)(Browser.CHROME);
 
-export const getModifierKey = async () => {
-  const mac = await isMac();
+export const getModifierKey = async (driver) => {
+  const mac = await isMac(driver);
   return mac ? Key.COMMAND : Key.CONTROL;
 };
 
@@ -46,7 +46,6 @@ afterAll(async () => {
     listener();
     process.removeListener('exit', listener);
   }
-  await driver.quit();
 });
 
 export const defaultTimeout = 10e3;

--- a/test/pageObjects/index.js
+++ b/test/pageObjects/index.js
@@ -1,5 +1,5 @@
-import {until} from 'selenium-webdriver';
-import {driver, defaultTimeout} from '../helpers';
+import {Builder, until} from 'selenium-webdriver';
+import {defaultTimeout} from '../helpers';
 
 const rootSelector = {css: '#root'};
 const finputDefaultSelector = {css: '#finput-default'};
@@ -8,14 +8,21 @@ const finputSwitchOptionsSelector = {css: '#finput-switch-options'};
 const finputSwitchOptionsButtonSelector = {css: '#finput-switch-options-button'};
 const nativeTextSelector = {css: '#native-text'};
 
-export const finputDefaultDelimiters = () => driver.findElement(finputDefaultSelector);
-export const finputReversedDelimiters = () => driver.findElement(finputReversedDelimitersSelector);
-export const finputSwitchOptions = () => driver.findElement(finputSwitchOptionsSelector);
-export const finputSwitchOptionsButton = () => driver.findElement(finputSwitchOptionsButtonSelector);
-export const nativeText = () => driver.findElement(nativeTextSelector);
+export const load = async (driver) => { 
 
-const root = () => driver.findElement(rootSelector);
-export const load = async () => {
   await driver.get(`${__baseUrl__}/`);
+
+  const root = () => driver.findElement(rootSelector);
   await driver.wait(until.elementLocated(root), defaultTimeout);
+
+  return {
+    driver,
+    finputDefaultDelimiters: () => driver.findElement(finputDefaultSelector),
+    finputReversedDelimiters: () => driver.findElement(finputReversedDelimitersSelector),
+    finputSwitchOptions: () => driver.findElement(finputSwitchOptionsSelector),
+    finputSwitchOptionsButton: () => driver.findElement(finputSwitchOptionsButtonSelector),
+    nativeText: () => driver.findElement(nativeTextSelector)
+  }
 };
+
+export const unload = (driver) => async () => await driver.quit();

--- a/test/specs/copy-paste.js
+++ b/test/specs/copy-paste.js
@@ -1,24 +1,55 @@
-import {load, finputReversedDelimiters, finputDefaultDelimiters} from '../pageObjects/index';
-import customCommandsFactory from '../customCommands';
+import { load, unload } from '../pageObjects/index';
+import { getDriver } from '../helpers';
+import { copyingAndPasting, itCopyingAndPasting } from '../customCommands';
 
-describe('copy and paste', () => {
-  beforeAll(load);
+describe('copy and paste', async () => {
+
+  let driver;
+  let finputDefaultDelimiters;
+  let finputReversedDelimiters;
+  let nativeText;
+
+  beforeAll(async () => {
+    driver = getDriver();
+    ({
+      finputDefaultDelimiters,
+      finputReversedDelimiters,
+      nativeText
+    } = await load(driver));
+  });
+
+  afterAll(async () => await unload(driver));
 
   describe('default delimiters', () => {
-    const {copyingAndPasting} = customCommandsFactory(finputDefaultDelimiters);
 
-    copyingAndPasting(`aaaaa`).shouldShow(``);
-    copyingAndPasting(`-12`).shouldShow(`-12.00`);
-    copyingAndPasting(`-.9`).shouldShow(`-0.90`);
-    copyingAndPasting(`7a7a.8a.`).shouldShow(`77.80`);
+    beforeAll(() => {
+      itCopyingAndPasting.expectCopyingAndPasting = copyingAndPasting({
+        driver,
+        finputElement: finputDefaultDelimiters,
+        nativeText
+      });
+    });
+
+    itCopyingAndPasting({ tested: `aaaaa`, expected: `` });
+    itCopyingAndPasting({ tested: `-12`, expected: `-12.00` });
+    itCopyingAndPasting({ tested: `-.9`, expected: `-0.90` });
+    itCopyingAndPasting({ tested: `7a7a.8a.`, expected: `77.80` });
   });
 
   describe('reversed delimiters', () => {
-    const {copyingAndPasting} = customCommandsFactory(finputReversedDelimiters);
 
-    copyingAndPasting(`aaaaa`).shouldShow(``);
-    copyingAndPasting(`-12`).shouldShow(`-12,00`);
-    copyingAndPasting(`-,9`).shouldShow(`-0,90`);
-    copyingAndPasting(`7a7a,8a,`).shouldShow(`77,80`);
+    beforeAll(() => {
+      itCopyingAndPasting.expectCopyingAndPasting = copyingAndPasting({
+        driver,
+        finputElement: finputReversedDelimiters,
+        nativeText
+      });
+    });
+
+    itCopyingAndPasting({ tested: `aaaaa`, expected: `` });
+    itCopyingAndPasting({ tested: `-12`, expected: `-12,00` });
+    itCopyingAndPasting({ tested: `-,9`, expected: `-0,90` });
+    itCopyingAndPasting({ tested: `7a7a,8a,`, expected: `77,80` });
   });
+  
 });

--- a/test/specs/cutting.js
+++ b/test/specs/cutting.js
@@ -1,30 +1,55 @@
-import {load, finputReversedDelimiters, finputDefaultDelimiters} from '../pageObjects/index';
-import customCommandsFactory from '../customCommands';
+import { load, unload } from '../pageObjects/index';
+import { getDriver } from '../helpers';
+import { cutting, itCutting } from '../customCommands';
 
 describe('cutting', () => {
-  beforeAll(load);
+
+  let driver;
+  let finputDefaultDelimiters;
+  let finputReversedDelimiters;
+
+  beforeAll(async () => {
+    driver = getDriver();
+    ({ 
+      finputDefaultDelimiters, 
+      finputReversedDelimiters 
+    } = await load(driver));
+  });
+
+  afterAll(async () => await unload(driver));
 
   describe('default delimiters', () => {
-    const {cutting} = customCommandsFactory(finputDefaultDelimiters);
+
+    beforeAll(() => {
+      itCutting.expectCutting = cutting({
+        driver,
+        finputElement: finputDefaultDelimiters
+      });
+    });
 
     // Cutting from input (should fully format unless no characters selected)
     // None selected
-    cutting(0).characters().from(`123456`).startingFrom(0).shouldShow(`123,456`);
-    cutting(2).characters().from(`12`).startingFrom(2).shouldShow(`12`);
-
-    cutting(4).characters().from(`123456`).startingFrom(1).shouldShow(`156.00`);
-    cutting(5).characters().from(`1234`).startingFrom(0).shouldShow(``);
+    itCutting({ cut: 0, startingFrom: 0, tested: `123456`, expected: `123,456` });
+    itCutting({ cut: 2, startingFrom: 2, tested: `12`, expected: `12` });
+    itCutting({ cut: 4, startingFrom: 1, tested: `123456`, expected: `156.00` });
+    itCutting({ cut: 5, startingFrom: 0, tested: `1234`, expected: `` });
   });
 
   describe('reversed delimiters', () => {
-    const {cutting} = customCommandsFactory(finputReversedDelimiters);
+
+    beforeAll(() => {
+      itCutting.expectCutting = cutting({
+        driver,
+        finputElement: finputReversedDelimiters
+      });
+    });
 
     // Cutting from input (should fully format unless no characters selected)
     // None selected
-    cutting(0).characters().from(`123456`).startingFrom(0).shouldShow(`123.456`);
-    cutting(2).characters().from(`12`).startingFrom(2).shouldShow(`12`);
-
-    cutting(4).characters().from(`123456`).startingFrom(1).shouldShow(`156,00`);
-    cutting(5).characters().from(`1234`).startingFrom(0).shouldShow(``);
+    itCutting({ cut: 0, startingFrom: 0, tested: `123456`, expected: `123.456` });
+    itCutting({ cut: 2, startingFrom: 2, tested: `12`, expected: `12` });
+    itCutting({ cut: 4, startingFrom: 1, tested: `123456`, expected: `156,00` });
+    itCutting({ cut: 5, startingFrom: 0, tested: `1234`,expected: `` });    
   });
+  
 });

--- a/test/specs/deletions.js
+++ b/test/specs/deletions.js
@@ -1,65 +1,79 @@
-import {load, finputDefaultDelimiters} from '../pageObjects/index';
-import customCommandsFactory from '../customCommands';
-
-const {typing} = customCommandsFactory(finputDefaultDelimiters);
+import { load, unload } from '../pageObjects/index';
+import { getDriver } from '../helpers';
+import { typing, itTyping } from '../customCommands';
 
 describe('deletions', () => {
-  beforeAll(load);
+  
+  let driver;
+  let finputDefaultDelimiters;
+
+  beforeAll(async () => {
+    driver = getDriver();
+    ({ finputDefaultDelimiters } = await load(driver));
+
+    itTyping.expectTyping = typing({
+      driver,
+      finputElement: finputDefaultDelimiters
+    });
+  });
+
+  afterAll(async () => await unload(driver));
 
   describe('deletes digit', () => {
     describe('when BACKSPACE is pressed while caret is positioned directly ahead of it', () => {
-      typing('123456.78↚').shouldShow('123,456.7').shouldHaveCaretAt(9);
-      typing('123456.78↚↚').shouldShow('123,456.').shouldHaveCaretAt(8);
-      typing('123456.78↚↚↚').shouldShow('123,456').shouldHaveCaretAt(7);
-      typing('123456.78↚↚↚↚').shouldShow('12,345').shouldHaveCaretAt(6);
-      typing('123456.78↚↚↚↚↚').shouldShow('1,234').shouldHaveCaretAt(5);
-      typing('123456.78↚↚↚↚↚↚').shouldShow('123').shouldHaveCaretAt(3);
-      typing('123456.78↚↚↚↚↚↚↚').shouldShow('12').shouldHaveCaretAt(2);
-      typing('123456.78↚↚↚↚↚↚↚↚').shouldShow('1').shouldHaveCaretAt(1);
-
-      typing('123456←↚').shouldShow('12,346').shouldHaveCaretAt(5);
-      typing('123456←←↚').shouldShow('12,356').shouldHaveCaretAt(4);
-      typing('123456←←←←↚').shouldShow('12,456').shouldHaveCaretAt(2);
-      typing('123456←←←←←←↚').shouldShow('23,456').shouldHaveCaretAt(0);
+      itTyping({ tested: '123456.78↚', expected: '123,456.7', expectedCaretAt: 9 });
+      itTyping({ tested: '123456.78↚↚', expected: '123,456.', expectedCaretAt: 8 });
+      itTyping({ tested: '123456.78↚↚↚', expected: '123,456', expectedCaretAt: 7 });
+      itTyping({ tested: '123456.78↚↚↚↚', expected: '12,345', expectedCaretAt: 6 });
+      itTyping({ tested: '123456.78↚↚↚↚↚', expected: '1,234', expectedCaretAt: 5 });
+      itTyping({ tested: '123456.78↚↚↚↚↚↚', expected: '123', expectedCaretAt: 3 });
+      itTyping({ tested: '123456.78↚↚↚↚↚↚↚', expected: '12', expectedCaretAt: 2 });
+      itTyping({ tested: '123456.78↚↚↚↚↚↚↚↚', expected: '1', expectedCaretAt: 1 });
+      
+      itTyping({ tested: '123456←↚', expected: '12,346', expectedCaretAt: 5 });
+      itTyping({ tested: '123456←←↚', expected: '12,356', expectedCaretAt: 4 });
+      itTyping({ tested: '123456←←←←↚', expected: '12,456', expectedCaretAt: 2 });
+      itTyping({ tested: '123456←←←←←←↚', expected: '23,456', expectedCaretAt: 0 });
     });
 
     describe('when DELETE is pressed while caret is positioned directly behind of it', () => {
-      typing('123456.78⇤↛').shouldShow('23,456.78').shouldHaveCaretAt(0);
-      typing('123456.78⇤↛↛').shouldShow('3,456.78').shouldHaveCaretAt(0);
-      typing('123456.78⇤↛↛↛').shouldShow('456.78').shouldHaveCaretAt(0);
-      typing('123456.78⇤↛↛↛↛').shouldShow('56.78').shouldHaveCaretAt(0);
-      typing('123456.78⇤↛↛↛↛↛').shouldShow('6.78').shouldHaveCaretAt(0);
-      typing('123456.78⇤↛↛↛↛↛↛').shouldShow('.78').shouldHaveCaretAt(0);
-      typing('123456.78⇤↛↛↛↛↛↛↛').shouldShow('78').shouldHaveCaretAt(0);
-      typing('123456.78⇤↛↛↛↛↛↛↛↛').shouldShow('8').shouldHaveCaretAt(0);
-      typing('123456.78⇤↛↛↛↛↛↛↛↛↛').shouldShow('').shouldHaveCaretAt(0);
+      itTyping({ tested: '123456.78⇤↛', expected: '23,456.78', expectedCaretAt: 0 });
+      itTyping({ tested: '123456.78⇤↛↛', expected: '3,456.78', expectedCaretAt: 0 });
+      itTyping({ tested: '123456.78⇤↛↛↛', expected: '456.78', expectedCaretAt: 0 });
+      itTyping({ tested: '123456.78⇤↛↛↛↛', expected: '56.78', expectedCaretAt: 0 });
+      itTyping({ tested: '123456.78⇤↛↛↛↛↛', expected: '6.78', expectedCaretAt: 0 });
+      itTyping({ tested: '123456.78⇤↛↛↛↛↛↛', expected: '.78', expectedCaretAt: 0 });
+      itTyping({ tested: '123456.78⇤↛↛↛↛↛↛↛', expected: '78', expectedCaretAt: 0 });
+      itTyping({ tested: '123456.78⇤↛↛↛↛↛↛↛↛', expected: '8', expectedCaretAt: 0 });
+      itTyping({ tested: '123456.78⇤↛↛↛↛↛↛↛↛↛', expected: '', expectedCaretAt: 0 });
 
-      typing('123456.78←↛').shouldShow('123,456.7').shouldHaveCaretAt(9);
-      typing('123456.78←←↛').shouldShow('123,456.8').shouldHaveCaretAt(8);
-      typing('123456.78←←←←↛').shouldShow('12,345.78').shouldHaveCaretAt(6);
-      typing('123456.78←←←←←↛').shouldShow('12,346.78').shouldHaveCaretAt(5);
+      itTyping({ tested: '123456.78←↛', expected: '123,456.7', expectedCaretAt: 9 });
+      itTyping({ tested: '123456.78←←↛', expected: '123,456.8', expectedCaretAt: 8 });
+      itTyping({ tested: '123456.78←←←←↛', expected: '12,345.78', expectedCaretAt: 6 });
+      itTyping({ tested: '123456.78←←←←←↛', expected: '12,346.78', expectedCaretAt: 5 });
     });
   });
 
   describe('traverses thousands delimiter', () => {
     describe('backwards one place if BACKSPACE is pressed when caret is positioned directly ahead of it', () => {
-      typing('123456←←←↚').shouldShow('123,456').shouldHaveCaretAt(3);
+      itTyping({ tested: '123456←←←↚', expected: '123,456', expectedCaretAt: 3 });
     });
 
     describe('forwards one place if DELETE is pressed when caret is positioned directly behind of it', () => {
-      typing('123456←←←←↛').shouldShow('123,456').shouldHaveCaretAt(4);
+      itTyping({ tested: '123456←←←←↛', expected: '123,456', expectedCaretAt: 4 });
     });
   });
 
   describe('deletes decimal delimiter', () => {
     describe('when BACKSPACE is pressed while caret is positioned directly ahead of it', () => {
-      typing('123456.78←←↚').shouldShow('12,345,678').shouldHaveCaretAt(8);
-      typing('123456.78←←↚.↚').shouldShow('12,345,678').shouldHaveCaretAt(8);
+      itTyping({ tested: '123456.78←←↚', expected: '12,345,678', expectedCaretAt: 8 });
+      itTyping({ tested: '123456.78←←↚.↚', expected: '12,345,678', expectedCaretAt: 8 });
     });
 
     describe('when DELETE is pressed while caret is positioned directly behind of it', () => {
-      typing('123456.78←←←↛').shouldShow('12,345,678').shouldHaveCaretAt(8);
-      typing('123456.78←←←↛.←↛').shouldShow('12,345,678').shouldHaveCaretAt(8);
+      itTyping({ tested: '123456.78←←←↛', expected: '12,345,678', expectedCaretAt: 8 });
+      itTyping({ tested: '123456.78←←←↛.←↛', expected: '12,345,678', expectedCaretAt: 8 });
     });
-  })
+  });
+  
 });

--- a/test/specs/formatting-decimals.js
+++ b/test/specs/formatting-decimals.js
@@ -1,65 +1,94 @@
-import {load, finputReversedDelimiters, finputDefaultDelimiters} from '../pageObjects/index';
-import customCommandsFactory from '../customCommands';
+import { load, unload } from '../pageObjects/index';
+import { getDriver } from '../helpers';
+import { typing, itTyping } from '../customCommands';
 
 describe('formatting decimals', () => {
-  beforeAll(load);
 
+  let driver;
+  let finputDefaultDelimiters;
+  let finputReversedDelimiters;
+  let nativeText;
+
+  beforeAll(async () => {
+    driver = getDriver();
+    ({ 
+      finputDefaultDelimiters, 
+      finputReversedDelimiters,
+      nativeText 
+    } = await load(driver));
+  });
+
+  afterAll(async () => await unload(driver));
 
   describe('default delimiters', () => {
-    const {typing} = customCommandsFactory(finputDefaultDelimiters);
+
+    beforeAll(() => {
+      itTyping.expectTyping = typing({ 
+        driver,
+        finputElement: finputDefaultDelimiters,
+        nativeText
+      });
+    });
 
     describe('while focused', () => {
-      typing(`0`).shouldShow(`0`);
-      typing(`10`).shouldShow(`10`);
-      typing(`1←0`).shouldShow(`1`);
-      typing(`0.5←0`).shouldShow(`0.05`);
-      typing(`0.5←0`).shouldShow(`0.05`);
-      typing(`0.5←←0`).shouldShow(`0.5`);
-      typing(`1.5←←0`).shouldShow(`10.5`);
-      typing(`0.5←←7`).shouldShow(`7.5`);
-      typing(`0.5←←←0`).shouldShow(`0.5`);
-      typing(`.8`).shouldShow(`.8`);
-      typing(`.8←0`).shouldShow(`.08`);
-      typing(`.8←←0`).shouldShow(`0.8`);
-      typing(`123456←←←←←.`).shouldShow(`12.34`);
-      typing(`12.345`).shouldShow(`12.34`);
-      typing(`12.34←←↚`).shouldShow(`1,234`);
-      typing(`12.34←←↚`).shouldShow(`1,234`);
+      itTyping({ tested: `0`, expected: `0` });
+      itTyping({ tested: `10`, expected: `10` });
+      itTyping({ tested: `1←0`, expected: `1` });
+      itTyping({ tested: `0.5←0`, expected: `0.05` });
+      itTyping({ tested: `0.5←0`, expected: `0.05` });
+      itTyping({ tested: `0.5←←0`, expected: `0.5` });
+      itTyping({ tested: `1.5←←0`, expected: `10.5` });
+      itTyping({ tested: `0.5←←7`, expected: `7.5` });
+      itTyping({ tested: `0.5←←←0`, expected: `0.5` });
+      itTyping({ tested: `.8`, expected: `.8` });
+      itTyping({ tested: `.8←0`, expected: `.08` });
+      itTyping({ tested: `.8←←0`, expected: `0.8` });
+      itTyping({ tested: `123456←←←←←.`, expected: `12.34` });
+      itTyping({ tested: `12.345`, expected: `12.34` });
+      itTyping({ tested: `12.34←←↚`, expected: `1,234` });
+      itTyping({ tested: `12.34←←↚`, expected: `1,234` });
     });
 
     describe('on blur', () => {
-      typing(`0.8`).thenBlurring().shouldShow(`0.80`);
-      typing(`.8`).thenBlurring().shouldShow(`0.80`);
-      typing(`8.88`).thenBlurring().shouldShow(`8.88`);
+      itTyping({ tested: `0.8`, blurAfter: true, expected: `0.80` });
+      itTyping({ tested: `.8`, blurAfter: true, expected: `0.80` });
+      itTyping({ tested: `8.88`, blurAfter: true, expected: `8.88` });
     });
   });
 
   describe('reversed delimiters', () => {
-    const {typing} = customCommandsFactory(finputReversedDelimiters);
+
+    beforeAll(() => {
+      itTyping.expectTyping = typing({ 
+        driver,
+        finputElement: finputReversedDelimiters,
+        nativeText
+      });
+    });
 
     describe('while focused', () => {
-      typing(`0`).shouldShow(`0`);
-      typing(`10`).shouldShow(`10`);
-      typing(`1←0`).shouldShow(`1`);
-      typing(`0,5←0`).shouldShow(`0,05`);
-      typing(`0,5←0`).shouldShow(`0,05`);
-      typing(`0,5←←0`).shouldShow(`0,5`);
-      typing(`1,5←←0`).shouldShow(`10,5`);
-      typing(`0,5←←7`).shouldShow(`7,5`);
-      typing(`0,5←←←0`).shouldShow(`0,5`);
-      typing(`,8`).shouldShow(`,8`);
-      typing(`,8←0`).shouldShow(`,08`);
-      typing(`,8←←0`).shouldShow(`0,8`);
-      typing(`123456←←←←←,`).shouldShow(`12,34`);
-      typing(`12,345`).shouldShow(`12,34`);
-      typing(`12,34←←↚`).shouldShow(`1.234`);
-      typing(`12,34←←↚`).shouldShow(`1.234`);
+      itTyping({ tested: `0`, expected: `0` });
+      itTyping({ tested: `10`, expected: `10` });
+      itTyping({ tested: `1←0`, expected: `1` });
+      itTyping({ tested: `0,5←0`, expected: `0,05` });
+      itTyping({ tested: `0,5←0`, expected: `0,05` });
+      itTyping({ tested: `0,5←←0`, expected: `0,5` });
+      itTyping({ tested: `1,5←←0`, expected: `10,5` });
+      itTyping({ tested: `0,5←←7`, expected: `7,5` });
+      itTyping({ tested: `0,5←←←0`, expected: `0,5` });
+      itTyping({ tested: `,8`, expected: `,8` });
+      itTyping({ tested: `,8←0`, expected: `,08` });
+      itTyping({ tested: `,8←←0`, expected: `0,8` });
+      itTyping({ tested: `123456←←←←←,`, expected: `12,34` });
+      itTyping({ tested: `12,345`, expected: `12,34` });
+      itTyping({ tested: `12,34←←↚`, expected: `1.234` });
+      itTyping({ tested: `12,34←←↚`, expected: `1.234` });
     });
 
     describe('on blur', () => {
-      typing(`0,8`).thenBlurring().shouldShow(`0,80`);
-      typing(`,8`).thenBlurring().shouldShow(`0,80`);
-      typing(`8,88`).thenBlurring().shouldShow(`8,88`);
+      itTyping({ tested: `0,8`, blurAfter: true, expected: `0,80` });
+      itTyping({ tested: `,8`, blurAfter: true, expected: `0,80` });
+      itTyping({ tested: `8,88`, blurAfter: true, expected: `8,88` });
     })
   });
 

--- a/test/specs/formatting-negatives.js
+++ b/test/specs/formatting-negatives.js
@@ -1,55 +1,84 @@
-import {load, finputReversedDelimiters, finputDefaultDelimiters} from '../pageObjects/index';
-import customCommandsFactory from '../customCommands';
+import { load, unload } from '../pageObjects/index';
+import { getDriver } from '../helpers';
+import { typing, itTyping } from '../customCommands';
 
 describe('formatting negatives', () => {
-  beforeAll(load);
+  
+  let driver;
+  let finputDefaultDelimiters;
+  let finputReversedDelimiters;
+  let nativeText;
 
+  beforeAll(async () => {
+    driver = getDriver();
+    ({ 
+      finputDefaultDelimiters, 
+      finputReversedDelimiters,
+      nativeText 
+    } = await load(driver));
+  });
+
+  afterAll(async () => await unload(driver));
 
   describe('default delimiters', () => {
-    const {typing} = customCommandsFactory(finputDefaultDelimiters);
+    
+    beforeAll(() => {
+      itTyping.expectTyping = typing({
+        driver,
+        finputElement: finputDefaultDelimiters,
+        nativeText
+      });
+    });
 
     describe('while focused', () => {
-      typing(`-`).shouldShow(`-`);
-      typing(`-0`).shouldShow(`-0`);
-      typing(`--`).shouldShow(`-`);
-      typing(`-←0`).shouldShow(`-`);
-      typing(`0-`).shouldShow(`0`);
-      typing(`0-`).shouldShow(`0`);
-      typing(`-1000`).shouldShow(`-1,000`);
-      typing(`-1k`).shouldShow(`-1,000`);
+      itTyping({ tested: `-`, expected: `-` });
+      itTyping({ tested: `-0`, expected: `-0` });
+      itTyping({ tested: `--`, expected: `-` });
+      itTyping({ tested: `-←0`, expected: `-` });
+      itTyping({ tested: `0-`, expected: `0` });
+      itTyping({ tested: `0-`, expected: `0` });
+      itTyping({ tested: `-1000`, expected: `-1,000` });
+      itTyping({ tested: `-1k`, expected: `-1,000` });
     });
 
     describe('on blur', () => {
-      typing(`-.`).thenBlurring().shouldShow(`-0.00`);
-      typing(`-`).thenBlurring().shouldShow(`-0.00`);
-      typing(`-0`).thenBlurring().shouldShow(`-0.00`);
-      typing(`-0.`).thenBlurring().shouldShow(`-0.00`);
-      typing(`-.66`).thenBlurring().shouldShow(`-0.66`);
-      typing(`-1000`).thenBlurring().shouldShow(`-1,000.00`);
+      itTyping({ tested: `-.`, blurAfter: true, expected: `-0.00` });
+      itTyping({ tested: `-`, blurAfter: true, expected: `-0.00` });
+      itTyping({ tested: `-0`, blurAfter: true, expected: `-0.00` });
+      itTyping({ tested: `-0.`, blurAfter: true, expected: `-0.00` });
+      itTyping({ tested: `-.66`, blurAfter: true, expected: `-0.66` });
+      itTyping({ tested: `-1000`, blurAfter: true, expected: `-1,000.00` });
     });
   });
 
   describe('reversed delimiters', () => {
-    const {typing} = customCommandsFactory(finputReversedDelimiters);
+
+    beforeAll(() => {
+      itTyping.expectTyping = typing({
+        driver,
+        finputElement: finputReversedDelimiters,
+        nativeText
+      });
+    });
 
     describe('while focused', () => {
-      typing(`-`).shouldShow(`-`);
-      typing(`-0`).shouldShow(`-0`);
-      typing(`--`).shouldShow(`-`);
-      typing(`-←0`).shouldShow(`-`);
-      typing(`0-`).shouldShow(`0`);
-      typing(`0-`).shouldShow(`0`);
-      typing(`-1000`).shouldShow(`-1.000`);
-      typing(`-1k`).shouldShow(`-1.000`);
+      itTyping({ tested: `-`, expected: `-` });
+      itTyping({ tested: `-0`, expected: `-0` });
+      itTyping({ tested: `--`, expected: `-` });
+      itTyping({ tested: `-←0`, expected: `-` });
+      itTyping({ tested: `0-`, expected: `0` });
+      itTyping({ tested: `0-`, expected: `0` });
+      itTyping({ tested: `-1000`, expected: `-1.000` });
+      itTyping({ tested: `-1k`, expected: `-1.000` });
     });
 
     describe('on blur', () => {
-      typing(`-,`).thenBlurring().shouldShow(`-0,00`);
-      typing(`-`).thenBlurring().shouldShow(`-0,00`);
-      typing(`-0`).thenBlurring().shouldShow(`-0,00`);
-      typing(`-0,`).thenBlurring().shouldShow(`-0,00`);
-      typing(`-,66`).thenBlurring().shouldShow(`-0,66`);
-      typing(`-1000`).thenBlurring().shouldShow(`-1.000,00`);
+      itTyping({ tested: `-,`, blurAfter: true, expected: `-0,00` });
+      itTyping({ tested: `-`, blurAfter: true, expected: `-0,00` });
+      itTyping({ tested: `-0`, blurAfter: true, expected: `-0,00` });
+      itTyping({ tested: `-0,`, blurAfter: true, expected: `-0,00` });
+      itTyping({ tested: `-,66`, blurAfter: true, expected: `-0,66` });
+      itTyping({ tested: `-1000`, blurAfter: true, expected: `-1.000,00` });
     });
   });
 

--- a/test/specs/modifiers.js
+++ b/test/specs/modifiers.js
@@ -1,28 +1,41 @@
-import {load, finputDefaultDelimiters} from '../pageObjects/index';
-import customCommandsFactory from '../customCommands';
-
-const {typing} = customCommandsFactory(finputDefaultDelimiters);
+import { load, unload } from '../pageObjects/index';
+import { getDriver } from '../helpers';
+import { typing, itTyping } from '../customCommands';
 
 describe('modifiers', () => {
-  beforeAll(load);
+
+  let driver;
+  let finputDefaultDelimiters;
+
+  beforeAll(async () => {
+    driver = getDriver();
+    ({ finputDefaultDelimiters } = await load(driver));
+    
+    itTyping.expectTyping = typing({
+      driver,
+      finputElement: finputDefaultDelimiters
+    });
+  });
+
+  afterAll(async () => await unload(driver));
 
   describe('are not blocked from activating keyboard shortcuts', () => {
     // TODO: find a way to test browser shortcuts blur the input (not currently working with chromedriver)
-    typing('k').whileModifierPressed().shouldShow('');
-    typing('m').whileModifierPressed().shouldShow('');
-    typing('b').whileModifierPressed().shouldShow('');
-    typing('l').whileModifierPressed().shouldShow('');
-    typing('h').whileModifierPressed().shouldShow('');
+    itTyping({ tested: 'k', pressModifier: true, expected: '' });
+    itTyping({ tested: 'm', pressModifier: true, expected: '' });
+    itTyping({ tested: 'b', pressModifier: true, expected: '' });
+    itTyping({ tested: 'l', pressModifier: true, expected: '' });
+    itTyping({ tested: 'h', pressModifier: true, expected: '' });
 
-    typing('0').whileModifierPressed().shouldShow('');
-    typing('1').whileModifierPressed().shouldShow('');
-    typing('2').whileModifierPressed().shouldShow('');
-    typing('3').whileModifierPressed().shouldShow('');
+    itTyping({ tested: '0', pressModifier: true, expected: '' });
+    itTyping({ tested: '1', pressModifier: true, expected: '' });
+    itTyping({ tested: '2', pressModifier: true, expected: '' });
+    itTyping({ tested: '3', pressModifier: true, expected: '' });
 
-    typing('-').whileModifierPressed().shouldShow('');
-    typing('+').whileModifierPressed().shouldShow('');
-    typing('.').whileModifierPressed().shouldShow('');
-    typing(',').whileModifierPressed().shouldShow('');
+    itTyping({ tested: '-', pressModifier: true, expected: '' });
+    itTyping({ tested: '+', pressModifier: true, expected: '' });
+    itTyping({ tested: '.', pressModifier: true, expected: '' });
+    itTyping({ tested: ',', pressModifier: true, expected: '' });
   });
 });
 ;

--- a/test/specs/shortcuts.js
+++ b/test/specs/shortcuts.js
@@ -1,130 +1,156 @@
-import {load, finputReversedDelimiters, finputDefaultDelimiters} from '../pageObjects/index';
-import customCommandsFactory from '../customCommands';
+import { load, unload } from '../pageObjects/index';
+import { getDriver } from '../helpers';
+import { typing, itTyping } from '../customCommands';
 
 describe('shortcuts', () => {
-  beforeAll(load);
+  
+  let driver;
+  let finputDefaultDelimiters;
+  let finputReversedDelimiters;
+
+  beforeAll(async () => {
+    driver = getDriver();
+    ({ 
+      finputDefaultDelimiters,
+      finputReversedDelimiters
+    } = await load(driver));
+  });
+
+  afterAll(async () => await unload(driver));
 
   describe('default delimiters', () => {
-    const {typing} = customCommandsFactory(finputDefaultDelimiters);
+
+    beforeAll(() => {
+      itTyping.expectTyping = typing({
+        driver,
+        finputElement: finputDefaultDelimiters
+      });
+    });
 
     describe('typed into empty field', () => {
       // TODO: fix bug which causes shortcuts to be capped to a limit
       for (let i = 1; i <= 2; i++) {
-        typing(`k`.padEnd(i, `k`)).shouldShow(`1` + `,000`.padEnd(i * 4, `,000`));
-        typing(`m`.padEnd(i, `m`)).shouldShow(`1` + `,000`.padEnd(i * 8, `,000`));
-        typing(`b`.padEnd(i, `b`)).shouldShow(`1` + `,000`.padEnd(i * 12, `,000`));
+        itTyping({ tested: `k`.padEnd(i, `k`), expected: `1` + `,000`.padEnd(i * 4, `,000`) });
+        itTyping({ tested: `m`.padEnd(i, `m`), expected: `1` + `,000`.padEnd(i * 8, `,000`) });
+        itTyping({ tested: `b`.padEnd(i, `b`), expected: `1` + `,000`.padEnd(i * 12, `,000`) });
       }
     });
 
     describe('entered onto end of integer number', () => {
-      typing(`1k`).shouldShow(`1,000`);
-      typing(`2m`).shouldShow(`2,000,000`);
-      typing(`3b`).shouldShow(`3,000,000,000`);
+      itTyping({ tested: `1k`, expected: `1,000` });
+      itTyping({ tested: `2m`, expected: `2,000,000` });
+      itTyping({ tested: `3b`, expected: `3,000,000,000` });
 
-      typing(`1k1`).shouldShow(`10,001`);
-      typing(`2m2`).shouldShow(`20,000,002`);
-      typing(`3b3`).shouldShow(`30,000,000,003`);
+      itTyping({ tested: `1k1`, expected: `10,001` });
+      itTyping({ tested: `2m2`, expected: `20,000,002` });
+      itTyping({ tested: `3b3`, expected: `30,000,000,003` });
 
-      typing(`1k1k`).shouldShow(`10,001,000`);
-      typing(`1m1m`).shouldShow(`10,000,001,000,000`);
-      typing(`1b1b`).shouldShow(`10,000,000,001,000,000,000`);
+      itTyping({ tested: `1k1k`, expected: `10,001,000` });
+      itTyping({ tested: `1m1m`, expected: `10,000,001,000,000` });
+      itTyping({ tested: `1b1b`, expected: `10,000,000,001,000,000,000` });
     });
 
     describe('entered onto end of decimal number', () => {
-      typing('.1k').shouldShow('100');
-      typing('.1m').shouldShow('100,000');
-      typing('.1b').shouldShow('100,000,000');
+      itTyping({ tested: '.1k', expected: '100' });
+      itTyping({ tested: '.1m', expected: '100,000' });
+      itTyping({ tested: '.1b', expected: '100,000,000' });
 
-      typing('1.1k').shouldShow('1,100');
-      typing('1.1m').shouldShow('1,100,000');
-      typing('1.1b').shouldShow('1,100,000,000');
+      itTyping({ tested: '1.1k', expected: '1,100' });
+      itTyping({ tested: '1.1m', expected: '1,100,000' });
+      itTyping({ tested: '1.1b', expected: '1,100,000,000' });
 
-      typing('1.01k').shouldShow('1,010');
-      typing('1.01m').shouldShow('1,010,000');
-      typing('1.01b').shouldShow('1,010,000,000');
+      itTyping({ tested: '1.01k', expected: '1,010' });
+      itTyping({ tested: '1.01m', expected: '1,010,000' });
+      itTyping({ tested: '1.01b', expected: '1,010,000,000' });
     });
 
     describe('entered into middle of whole number', () => {
-      typing('12345←k').shouldShow('12,345,000');
-      typing('12345←m').shouldShow('12,345,000,000');
-      typing('12345←b').shouldShow('12,345,000,000,000');
+      itTyping({ tested: '12345←k', expected: '12,345,000' });
+      itTyping({ tested: '12345←m', expected: '12,345,000,000' });
+      itTyping({ tested: '12345←b', expected: '12,345,000,000,000' });
 
-      typing('12345←←k').shouldShow('12,345,000');
-      typing('12345←←m').shouldShow('12,345,000,000');
-      typing('12345←←b').shouldShow('12,345,000,000,000');
+      itTyping({ tested: '12345←←k', expected: '12,345,000' });
+      itTyping({ tested: '12345←←m', expected: '12,345,000,000' });
+      itTyping({ tested: '12345←←b', expected: '12,345,000,000,000' });
     });
 
     describe('combined', () => {
-      typing(`kb`).shouldShow(`1,000,000,000,000`);
-      typing(`bk`).shouldShow(`1,000,000,000,000`);
+      itTyping({ tested: `kb`, expected: `1,000,000,000,000` });
+      itTyping({ tested: `bk`, expected: `1,000,000,000,000` });
 
-      typing(`km`).shouldShow(`1,000,000,000`);
-      typing(`mk`).shouldShow(`1,000,000,000`);
+      itTyping({ tested: `km`, expected: `1,000,000,000` });
+      itTyping({ tested: `mk`, expected: `1,000,000,000` });
 
-      typing(`bm`).shouldShow(`1,000,000,000,000,000`);
-      typing(`mb`).shouldShow(`1,000,000,000,000,000`);
+      itTyping({ tested: `bm`, expected: `1,000,000,000,000,000` });
+      itTyping({ tested: `mb`, expected: `1,000,000,000,000,000` });
     });
   });
 
   describe('reversed delimiters', () => {
-    const {typing} = customCommandsFactory(finputReversedDelimiters);
+
+    beforeAll(() => {
+      itTyping.expectTyping = typing({
+        driver,
+        finputElement: finputReversedDelimiters
+      });
+    });
 
     test('typed into empty field', () => {
       // TODO: fix bug which causes shortcuts to be capped to a limit
       for (let i = 1; i <= 2; i++) {
-        typing(`k`.padEnd(i, `k`)).shouldShow(`1` + `.000`.padEnd(i * 4, `.000`));
-        typing(`m`.padEnd(i, `m`)).shouldShow(`1` + `.000`.padEnd(i * 8, `.000`));
-        typing(`b`.padEnd(i, `b`)).shouldShow(`1` + `.000`.padEnd(i * 12, `.000`));
+        itTyping({ tested: `k`.padEnd(i, `k`), expected: `1` + `.000`.padEnd(i * 4, `.000`) });
+        itTyping({ tested: `m`.padEnd(i, `m`), expected: `1` + `.000`.padEnd(i * 8, `.000`) });
+        itTyping({ tested: `b`.padEnd(i, `b`), expected: `1` + `.000`.padEnd(i * 12, `.000`) });
       }
     });
 
     describe('entered onto end of integer number', () => {
-      typing(`1k`).shouldShow(`1.000`);
-      typing(`2m`).shouldShow(`2.000.000`);
-      typing(`3b`).shouldShow(`3.000.000.000`);
+      itTyping({ tested: `1k`, expected: `1.000` });
+      itTyping({ tested: `2m`, expected: `2.000.000` });
+      itTyping({ tested: `3b`, expected: `3.000.000.000` });
 
-      typing(`1k1`).shouldShow(`10.001`);
-      typing(`2m2`).shouldShow(`20.000.002`);
-      typing(`3b3`).shouldShow(`30.000.000.003`);
+      itTyping({ tested: `1k1`, expected: `10.001` });
+      itTyping({ tested: `2m2`, expected: `20.000.002` });
+      itTyping({ tested: `3b3`, expected: `30.000.000.003` });
 
-      typing(`1k1k`).shouldShow(`10.001.000`);
-      typing(`1m1m`).shouldShow(`10.000.001.000.000`);
-      typing(`1b1b`).shouldShow(`10.000.000.001.000.000.000`);
+      itTyping({ tested: `1k1k`, expected: `10.001.000` });
+      itTyping({ tested: `1m1m`, expected: `10.000.001.000.000` });
+      itTyping({ tested: `1b1b`, expected: `10.000.000.001.000.000.000` });
     });
 
     describe('entered onto end of decimal number', () => {
-      typing(',1k').shouldShow('100');
-      typing(',1m').shouldShow('100.000');
-      typing(',1b').shouldShow('100.000.000');
+      itTyping({ tested: ',1k', expected: '100' });
+      itTyping({ tested: ',1m', expected: '100.000' });
+      itTyping({ tested: ',1b', expected: '100.000.000' });
 
-      typing('1,1k').shouldShow('1.100');
-      typing('1,1m').shouldShow('1.100.000');
-      typing('1,1b').shouldShow('1.100.000.000');
+      itTyping({ tested: '1,1k', expected: '1.100' });
+      itTyping({ tested: '1,1m', expected: '1.100.000' });
+      itTyping({ tested: '1,1b', expected: '1.100.000.000' });
 
-      typing('1,01k').shouldShow('1.010');
-      typing('1,01m').shouldShow('1.010.000');
-      typing('1,01b').shouldShow('1.010.000.000');
+      itTyping({ tested: '1,01k', expected: '1.010' });
+      itTyping({ tested: '1,01m', expected: '1.010.000' });
+      itTyping({ tested: '1,01b', expected: '1.010.000.000' });
     });
 
     describe('entered into middle of whole number', () => {
-      typing('12345←k').shouldShow('12.345.000');
-      typing('12345←m').shouldShow('12.345.000.000');
-      typing('12345←b').shouldShow('12.345.000.000.000');
+      itTyping({ tested: '12345←k', expected: '12.345.000' });
+      itTyping({ tested: '12345←m', expected: '12.345.000.000' });
+      itTyping({ tested: '12345←b', expected: '12.345.000.000.000' });
 
-      typing('12345←←k').shouldShow('12.345.000');
-      typing('12345←←m').shouldShow('12.345.000.000');
-      typing('12345←←b').shouldShow('12.345.000.000.000');
+      itTyping({ tested: '12345←←k', expected: '12.345.000' });
+      itTyping({ tested: '12345←←m', expected: '12.345.000.000' });
+      itTyping({ tested: '12345←←b', expected: '12.345.000.000.000' });
     });
 
     describe('combined', () => {
-      typing(`kb`).shouldShow(`1.000.000.000.000`);
-      typing(`bk`).shouldShow(`1.000.000.000.000`);
+      itTyping({ tested: `kb`, expected: `1.000.000.000.000` });
+      itTyping({ tested: `bk`, expected: `1.000.000.000.000` });
 
-      typing(`km`).shouldShow(`1.000.000.000`);
-      typing(`mk`).shouldShow(`1.000.000.000`);
+      itTyping({ tested: `km`, expected: `1.000.000.000` });
+      itTyping({ tested: `mk`, expected: `1.000.000.000` });
 
-      typing(`bm`).shouldShow(`1.000.000.000.000.000`);
-      typing(`mb`).shouldShow(`1.000.000.000.000.000`);
+      itTyping({ tested: `bm`, expected: `1.000.000.000.000.000` });
+      itTyping({ tested: `mb`, expected: `1.000.000.000.000.000` });
     });
   });
 });

--- a/test/specs/switching-delimiters.js
+++ b/test/specs/switching-delimiters.js
@@ -1,52 +1,70 @@
-import { load, finputSwitchOptions } from '../pageObjects/index';
-import customCommandsFactory from '../customCommands';
-
-const { typing } = customCommandsFactory(finputSwitchOptions);
+import { load, unload } from '../pageObjects/index';
+import { getDriver } from '../helpers';
+import { typing, itTyping } from '../customCommands';
 
 describe('Switching delimiters', () => {
-  beforeAll(load);
+  
+  let driver;
+  let finputSwitchOptions;
+  let finputSwitchOptionsButton;
+
+  beforeAll(async () => {
+    driver = getDriver();
+    ({
+      finputSwitchOptions, 
+      finputSwitchOptionsButton
+    } = await load(driver));
+
+    itTyping.expectTyping = typing({ 
+      driver,
+      finputElement: finputSwitchOptions, 
+      finputSwitchOptionsButton 
+    });
+  });
+
+  afterAll(async () => await unload(driver));
 
   // only decimal
-  typing('.99').thenSwitchingDelimiters().shouldShow('0,99');
-  typing(',99').thenSwitchingDelimiters().shouldShow('0.99');
-  typing('.99').thenSwitchingDelimiters().shouldShow('0,99');
-  typing(',99').thenSwitchingDelimiters().shouldShow('0.99');
+  itTyping({ tested: '.99', switchDelimiter: true , expected: '0,99' });
+  itTyping({ tested: ',99', switchDelimiter: true , expected: '0.99' });
+  itTyping({ tested: '.99', switchDelimiter: true , expected: '0,99' });
+  itTyping({ tested: ',99', switchDelimiter: true , expected: '0.99' });
 
-  typing('-.99').thenSwitchingDelimiters().shouldShow('-0,99');
-  typing('-,99').thenSwitchingDelimiters().shouldShow('-0.99');
-  typing('-.99').thenSwitchingDelimiters().shouldShow('-0,99');
-  typing('-,99').thenSwitchingDelimiters().shouldShow('-0.99');
+  itTyping({ tested: '-.99', switchDelimiter: true , expected: '-0,99' });
+  itTyping({ tested: '-,99', switchDelimiter: true , expected: '-0.99' });
+  itTyping({ tested: '-.99', switchDelimiter: true , expected: '-0,99' });
+  itTyping({ tested: '-,99', switchDelimiter: true , expected: '-0.99' });
 
   // only thousands
-  typing('1k').thenSwitchingDelimiters().shouldShow('1.000,00');
-  typing('1k').thenSwitchingDelimiters().shouldShow('1,000.00');
-  typing('1k').thenSwitchingDelimiters().shouldShow('1.000,00');
-  typing('1k').thenSwitchingDelimiters().shouldShow('1,000.00');
+  itTyping({ tested: '1k', switchDelimiter: true , expected: '1.000,00' });
+  itTyping({ tested: '1k', switchDelimiter: true , expected: '1,000.00' });
+  itTyping({ tested: '1k', switchDelimiter: true , expected: '1.000,00' });
+  itTyping({ tested: '1k', switchDelimiter: true , expected: '1,000.00' });
 
-  typing('-1k').thenSwitchingDelimiters().shouldShow('-1.000,00');
-  typing('-1k').thenSwitchingDelimiters().shouldShow('-1,000.00');
-  typing('-1k').thenSwitchingDelimiters().shouldShow('-1.000,00');
-  typing('-1k').thenSwitchingDelimiters().shouldShow('-1,000.00');
+  itTyping({ tested: '-1k', switchDelimiter: true , expected: '-1.000,00' });
+  itTyping({ tested: '-1k', switchDelimiter: true , expected: '-1,000.00' });
+  itTyping({ tested: '-1k', switchDelimiter: true , expected: '-1.000,00' });
+  itTyping({ tested: '-1k', switchDelimiter: true , expected: '-1,000.00' });
 
   // thousands and decimals
-  typing('123456.78').thenSwitchingDelimiters().shouldShow('123.456,78');
-  typing('123456,78').thenSwitchingDelimiters().shouldShow('123,456.78');
-  typing('123456.78').thenSwitchingDelimiters().shouldShow('123.456,78');
-  typing('123456,78').thenSwitchingDelimiters().shouldShow('123,456.78');
+  itTyping({ tested: '123456.78', switchDelimiter: true , expected: '123.456,78' });
+  itTyping({ tested: '123456,78', switchDelimiter: true , expected: '123,456.78' });
+  itTyping({ tested: '123456.78', switchDelimiter: true , expected: '123.456,78' });
+  itTyping({ tested: '123456,78', switchDelimiter: true , expected: '123,456.78' });
 
-  typing('-123456.78').thenSwitchingDelimiters().shouldShow('-123.456,78');
-  typing('-123456,78').thenSwitchingDelimiters().shouldShow('-123,456.78');
-  typing('-123456.78').thenSwitchingDelimiters().shouldShow('-123.456,78');
-  typing('-123456,78').thenSwitchingDelimiters().shouldShow('-123,456.78');
+  itTyping({ tested: '-123456.78', switchDelimiter: true , expected: '-123.456,78' });
+  itTyping({ tested: '-123456,78', switchDelimiter: true , expected: '-123,456.78' });
+  itTyping({ tested: '-123456.78', switchDelimiter: true , expected: '-123.456,78' });
+  itTyping({ tested: '-123456,78', switchDelimiter: true , expected: '-123,456.78' });
 
   // many thousands
-  typing('1b.99').thenSwitchingDelimiters().shouldShow('1.000.000.000,99');
-  typing('1b,99').thenSwitchingDelimiters().shouldShow('1,000,000,000.99');
-  typing('1b.99').thenSwitchingDelimiters().shouldShow('1.000.000.000,99');
-  typing('1b,99').thenSwitchingDelimiters().shouldShow('1,000,000,000.99');
+  itTyping({ tested: '1b.99', switchDelimiter: true , expected: '1.000.000.000,99' });
+  itTyping({ tested: '1b,99', switchDelimiter: true , expected: '1,000,000,000.99' });
+  itTyping({ tested: '1b.99', switchDelimiter: true , expected: '1.000.000.000,99' });
+  itTyping({ tested: '1b,99', switchDelimiter: true , expected: '1,000,000,000.99' });
 
-  typing('-1b.99').thenSwitchingDelimiters().shouldShow('-1.000.000.000,99');
-  typing('-1b,99').thenSwitchingDelimiters().shouldShow('-1,000,000,000.99');
-  typing('-1b.99').thenSwitchingDelimiters().shouldShow('-1.000.000.000,99');
-  typing('-1b,99').thenSwitchingDelimiters().shouldShow('-1,000,000,000.99');
+  itTyping({ tested: '-1b.99', switchDelimiter: true , expected: '-1.000.000.000,99' });
+  itTyping({ tested: '-1b,99', switchDelimiter: true , expected: '-1,000,000,000.99' });
+  itTyping({ tested: '-1b.99', switchDelimiter: true , expected: '-1.000.000.000,99' });
+  itTyping({ tested: '-1b,99', switchDelimiter: true , expected: '-1,000,000,000.99' });
 });

--- a/test/specs/traversals.js
+++ b/test/specs/traversals.js
@@ -1,28 +1,41 @@
-import {load, finputDefaultDelimiters} from '../pageObjects/index';
-import customCommandsFactory from '../customCommands';
-
-const {typing} = customCommandsFactory(finputDefaultDelimiters);
+import { load, unload } from '../pageObjects/index';
+import { getDriver } from '../helpers';
+import { typing, itTyping } from '../customCommands';
 
 describe('traversals', () => {
-  beforeAll(load);
+
+  let driver;
+  let finputDefaultDelimiters;
+
+  beforeAll(async () => {
+    driver = getDriver();
+    ({ finputDefaultDelimiters } = await load(driver));
+    
+    itTyping.expectTyping = typing({
+      driver,
+      finputElement: finputDefaultDelimiters
+    });
+  });
+
+  afterAll(async () => await unload(driver));
 
   describe('supports HOME and END keys sending caret to start / end of field', () => {
-    typing(`12⇤3`).shouldShow(`312`).shouldHaveFocus(true).shouldHaveCaretAt(1);
-    typing(`123⇤⇤4`).shouldShow(`4,123`).shouldHaveCaretAt(1);
-    typing(`123⇤⇥4`).shouldShow(`1,234`).shouldHaveCaretAt(5);
-    typing(`123⇤⇥4⇤5`).shouldShow(`51,234`).shouldHaveCaretAt(1);
+    itTyping({ tested: `12⇤3`, expected: `312`, expectFocus: true, expectCaretAt: 1 });
+    itTyping({ tested: `123⇤⇤4`, expected: `4,123`, expectCaretAt: 1 });
+    itTyping({ tested: `123⇤⇥4`, expected: `1,234`, expectCaretAt: 5 });
+    itTyping({ tested: `123⇤⇥4⇤5`, expected: `51,234`, expectCaretAt: 1 });
   });
 
   describe('supports left and right ARROW keys shifting caret left / right one caret', () => {
-    typing(`123456←8`).shouldShow(`1,234,586`);
-    typing(`123456←←8`).shouldShow(`1,234,856`);
-    typing(`123456←←←8`).shouldShow(`1,238,456`);
+    itTyping({ tested: `123456←8`, expected: `1,234,586` });
+    itTyping({ tested: `123456←←8`, expected: `1,234,856` });
+    itTyping({ tested: `123456←←←8`, expected: `1,238,456` });
   });
 
   describe('supports up and down ARROW keys sending caret to start / end of field', () => {
-    typing(`12↑3`).shouldShow(`312`).shouldHaveFocus(true).shouldHaveCaretAt(1);
-    typing(`123↑↑4`).shouldShow(`4,123`).shouldHaveCaretAt(1);
-    typing(`123↑↓4`).shouldShow(`1,234`).shouldHaveCaretAt(5);
-    typing(`123↑↓4↑5`).shouldShow(`51,234`).shouldHaveCaretAt(1);
+    itTyping({ tested: `12↑3`, expected: `312`, expectFocus: true, expectCaretAt: 1 });
+    itTyping({ tested: `123↑↑4`, expected: `4,123`, expectCaretAt: 1 });
+    itTyping({ tested: `123↑↓4`, expected: `1,234`, expectCaretAt: 5 });
+    itTyping({ tested: `123↑↓4↑5`, expected: `51,234`, expectCaretAt: 1 });
   });
 });


### PR DESCRIPTION
Refactoring of how the custom commands are consumed by the test specs.
Each spec need to get a driver, load it before all the tests and unload it after all the tests.
`customCommands` now exports functions to be composed. 
A set of functions to run the expectation in the `it` code, and a set of helpers to automate the writing of the `it` functions.

Note: although all the specs need to get a driver, there is only one instance of driver shared by all the specs (tests are run in sequence). This can change - and it will be easy to change the code with this refactoring - but so far I have had timeout issues when creating many instances, and have not figured out what is the exact issue.