### PR TITLE
chore: test refactoring to use separate environments per spec

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -14,29 +14,29 @@ const getSeleniumURL = () => {
   return 'http://localhost:4444/wd/hub'
 };
 
-
-
-export const driver = new Builder()
+const driver = new Builder()
   .withCapabilities(capabilities)
   .usingServer(getSeleniumURL())
   .build();
 
-export const isMac = async () => {
+export const getDriver = () => driver;
+
+export const isMac = async (driver) => {
   const capabilities = await driver.getCapabilities();
   const os = capabilities.get(Capability.PLATFORM);
   return os.toUpperCase().indexOf(Platform.MAC) >= 0;
 };
 
-export const isBrowser = async (browserName) => {
+const isBrowser = (driver) => async (browserName) => {
   const capabilities = await driver.getCapabilities();
   const browser = capabilities.get(Capability.BROWSER_NAME);
   return browser.indexOf(browserName) >= 0;
 };
 
-export const isChrome = async () => isBrowser(Browser.CHROME);
+export const isChrome = async (driver) => isBrowser(driver)(Browser.CHROME);
 
-export const getModifierKey = async () => {
-  const mac = await isMac();
+export const getModifierKey = async (driver) => {
+  const mac = await isMac(driver);
   return mac ? Key.COMMAND : Key.CONTROL;
 };
 
@@ -46,7 +46,6 @@ afterAll(async () => {
     listener();
     process.removeListener('exit', listener);
   }
-  await driver.quit();
 });
 
 export const defaultTimeout = 10e3;

--- a/test/pageObjects/index.js
+++ b/test/pageObjects/index.js
@@ -8,14 +8,20 @@ const finputSwitchOptionsSelector = {css: '#finput-switch-options'};
 const finputSwitchOptionsButtonSelector = {css: '#finput-switch-options-button'};
 const nativeTextSelector = {css: '#native-text'};
 
-export const finputDefaultDelimiters = () => driver.findElement(finputDefaultSelector);
-export const finputReversedDelimiters = () => driver.findElement(finputReversedDelimitersSelector);
-export const finputSwitchOptions = () => driver.findElement(finputSwitchOptionsSelector);
-export const finputSwitchOptionsButton = () => driver.findElement(finputSwitchOptionsButtonSelector);
-export const nativeText = () => driver.findElement(nativeTextSelector);
-
-const root = () => driver.findElement(rootSelector);
-export const load = async () => {
+export const load = async (driver) => {
   await driver.get(`${__baseUrl__}/`);
+
+  const root = () => driver.findElement(rootSelector);
   await driver.wait(until.elementLocated(root), defaultTimeout);
+
+  return {
+    driver,
+    finputDefaultDelimiters: () => driver.findElement(finputDefaultSelector),
+    finputReversedDelimiters: () => driver.findElement(finputReversedDelimitersSelector),
+    finputSwitchOptions: () => driver.findElement(finputSwitchOptionsSelector),
+    finputSwitchOptionsButton: () => driver.findElement(finputSwitchOptionsButtonSelector),
+    nativeText: () => driver.findElement(nativeTextSelector)
+  };
 };
+
+export const unload = async (driver) => await driver.quit();

--- a/test/specs/copy-paste.js
+++ b/test/specs/copy-paste.js
@@ -1,24 +1,53 @@
-import {load, finputReversedDelimiters, finputDefaultDelimiters} from '../pageObjects/index';
-import customCommandsFactory from '../customCommands';
+import { load, unload } from '../pageObjects/index';
+import { getDriver } from '../helpers';
+import createCommands from '../customCommands';
 
 describe('copy and paste', () => {
-  beforeAll(load);
+  let driver;
+  let finputDefaultDelimiters;
+  let finputReversedDelimiters;
+  let nativeText;
+  
+  const test = createCommands();
+
+  beforeAll(async () => {
+    driver = getDriver();
+    ({
+      finputDefaultDelimiters,
+      finputReversedDelimiters,
+      nativeText
+    } = await load(driver));
+  });
+
+  afterAll(async () => await unload(driver));
 
   describe('default delimiters', () => {
-    const {copyingAndPasting} = customCommandsFactory(finputDefaultDelimiters);
+    beforeAll(() => {
+      test.withEnvironment({
+        driver,
+        finputElement: finputDefaultDelimiters,
+        nativeText
+      })
+    });
 
-    copyingAndPasting(`aaaaa`).shouldShow(``);
-    copyingAndPasting(`-12`).shouldShow(`-12.00`);
-    copyingAndPasting(`-.9`).shouldShow(`-0.90`);
-    copyingAndPasting(`7a7a.8a.`).shouldShow(`77.80`);
+    test().copyingAndPasting(`aaaaa`).shouldShow(``);
+    test().copyingAndPasting(`-12`).shouldShow(`-12.00`);
+    test().copyingAndPasting(`-.9`).shouldShow(`-0.90`);
+    test().copyingAndPasting(`7a7a.8a.`).shouldShow(`77.80`);
   });
 
   describe('reversed delimiters', () => {
-    const {copyingAndPasting} = customCommandsFactory(finputReversedDelimiters);
+    beforeAll(() => {
+      test.withEnvironment({
+        driver,
+        finputElement: finputReversedDelimiters,
+        nativeText
+      })
+    });
 
-    copyingAndPasting(`aaaaa`).shouldShow(``);
-    copyingAndPasting(`-12`).shouldShow(`-12,00`);
-    copyingAndPasting(`-,9`).shouldShow(`-0,90`);
-    copyingAndPasting(`7a7a,8a,`).shouldShow(`77,80`);
+    test().copyingAndPasting(`aaaaa`).shouldShow(``);
+    test().copyingAndPasting(`-12`).shouldShow(`-12,00`);
+    test().copyingAndPasting(`-,9`).shouldShow(`-0,90`);
+    test().copyingAndPasting(`7a7a,8a,`).shouldShow(`77,80`);
   });
 });

--- a/test/specs/cutting.js
+++ b/test/specs/cutting.js
@@ -1,30 +1,55 @@
-import {load, finputReversedDelimiters, finputDefaultDelimiters} from '../pageObjects/index';
-import customCommandsFactory from '../customCommands';
+import { load, unload } from '../pageObjects/index';
+import { getDriver } from '../helpers';
+import createCommands from '../customCommands';
 
 describe('cutting', () => {
-  beforeAll(load);
+  let driver;
+  let finputDefaultDelimiters;
+  let finputReversedDelimiters;
+
+  const test = createCommands();
+
+  beforeAll(async () => {
+    driver = getDriver();
+    ({
+      finputDefaultDelimiters,
+      finputReversedDelimiters
+    } = await load(driver));
+  });
+
+  afterAll(async () => await unload(driver));
 
   describe('default delimiters', () => {
-    const {cutting} = customCommandsFactory(finputDefaultDelimiters);
+    beforeAll(() => {
+      test.withEnvironment({
+        driver,
+        finputElement: finputDefaultDelimiters
+      });
+    });
 
     // Cutting from input (should fully format unless no characters selected)
     // None selected
-    cutting(0).characters().from(`123456`).startingFrom(0).shouldShow(`123,456`);
-    cutting(2).characters().from(`12`).startingFrom(2).shouldShow(`12`);
+    test().cutting(0).characters().from(`123456`).startingFrom(0).shouldShow(`123,456`);
+    test().cutting(2).characters().from(`12`).startingFrom(2).shouldShow(`12`);
 
-    cutting(4).characters().from(`123456`).startingFrom(1).shouldShow(`156.00`);
-    cutting(5).characters().from(`1234`).startingFrom(0).shouldShow(``);
+    test().cutting(4).characters().from(`123456`).startingFrom(1).shouldShow(`156.00`);
+    test().cutting(5).characters().from(`1234`).startingFrom(0).shouldShow(``);
   });
 
   describe('reversed delimiters', () => {
-    const {cutting} = customCommandsFactory(finputReversedDelimiters);
+    beforeAll(() => {
+      test.withEnvironment({
+        driver,
+        finputElement: finputReversedDelimiters
+      });
+    });
 
     // Cutting from input (should fully format unless no characters selected)
     // None selected
-    cutting(0).characters().from(`123456`).startingFrom(0).shouldShow(`123.456`);
-    cutting(2).characters().from(`12`).startingFrom(2).shouldShow(`12`);
+    test().cutting(0).characters().from(`123456`).startingFrom(0).shouldShow(`123.456`);
+    test().cutting(2).characters().from(`12`).startingFrom(2).shouldShow(`12`);
 
-    cutting(4).characters().from(`123456`).startingFrom(1).shouldShow(`156,00`);
-    cutting(5).characters().from(`1234`).startingFrom(0).shouldShow(``);
+    test().cutting(4).characters().from(`123456`).startingFrom(1).shouldShow(`156,00`);
+    test().cutting(5).characters().from(`1234`).startingFrom(0).shouldShow(``);
   });
 });

--- a/test/specs/deletions.js
+++ b/test/specs/deletions.js
@@ -1,65 +1,79 @@
-import {load, finputDefaultDelimiters} from '../pageObjects/index';
-import customCommandsFactory from '../customCommands';
-
-const {typing} = customCommandsFactory(finputDefaultDelimiters);
+import { load, unload } from '../pageObjects/index';
+import { getDriver } from '../helpers';
+import createCommands from '../customCommands';
 
 describe('deletions', () => {
-  beforeAll(load);
+  let driver;
+  let finputDefaultDelimiters;
+
+  const test = createCommands();
+
+  beforeAll(async () => {
+    driver = getDriver();
+    ({ finputDefaultDelimiters } = await load(driver));
+
+    test.withEnvironment({
+      driver,
+      finputElement: finputDefaultDelimiters
+    });
+  });
+
+  afterAll(async () => await unload(driver));
 
   describe('deletes digit', () => {
     describe('when BACKSPACE is pressed while caret is positioned directly ahead of it', () => {
-      typing('123456.78↚').shouldShow('123,456.7').shouldHaveCaretAt(9);
-      typing('123456.78↚↚').shouldShow('123,456.').shouldHaveCaretAt(8);
-      typing('123456.78↚↚↚').shouldShow('123,456').shouldHaveCaretAt(7);
-      typing('123456.78↚↚↚↚').shouldShow('12,345').shouldHaveCaretAt(6);
-      typing('123456.78↚↚↚↚↚').shouldShow('1,234').shouldHaveCaretAt(5);
-      typing('123456.78↚↚↚↚↚↚').shouldShow('123').shouldHaveCaretAt(3);
-      typing('123456.78↚↚↚↚↚↚↚').shouldShow('12').shouldHaveCaretAt(2);
-      typing('123456.78↚↚↚↚↚↚↚↚').shouldShow('1').shouldHaveCaretAt(1);
+      test().typing('123456.78↚').shouldShow('123,456.7').shouldHaveCaretAt(9);
+      test().typing('123456.78↚↚').shouldShow('123,456.').shouldHaveCaretAt(8);
+      test().typing('123456.78↚↚↚').shouldShow('123,456').shouldHaveCaretAt(7);
+      test().typing('123456.78↚↚↚↚').shouldShow('12,345').shouldHaveCaretAt(6);
+      test().typing('123456.78↚↚↚↚↚').shouldShow('1,234').shouldHaveCaretAt(5);
+      test().typing('123456.78↚↚↚↚↚↚').shouldShow('123').shouldHaveCaretAt(3);
+      test().typing('123456.78↚↚↚↚↚↚↚').shouldShow('12').shouldHaveCaretAt(2);
+      test().typing('123456.78↚↚↚↚↚↚↚↚').shouldShow('1').shouldHaveCaretAt(1);
 
-      typing('123456←↚').shouldShow('12,346').shouldHaveCaretAt(5);
-      typing('123456←←↚').shouldShow('12,356').shouldHaveCaretAt(4);
-      typing('123456←←←←↚').shouldShow('12,456').shouldHaveCaretAt(2);
-      typing('123456←←←←←←↚').shouldShow('23,456').shouldHaveCaretAt(0);
+      test().typing('123456←↚').shouldShow('12,346').shouldHaveCaretAt(5);
+      test().typing('123456←←↚').shouldShow('12,356').shouldHaveCaretAt(4);
+      test().typing('123456←←←←↚').shouldShow('12,456').shouldHaveCaretAt(2);
+      test().typing('123456←←←←←←↚').shouldShow('23,456').shouldHaveCaretAt(0);
     });
 
     describe('when DELETE is pressed while caret is positioned directly behind of it', () => {
-      typing('123456.78⇤↛').shouldShow('23,456.78').shouldHaveCaretAt(0);
-      typing('123456.78⇤↛↛').shouldShow('3,456.78').shouldHaveCaretAt(0);
-      typing('123456.78⇤↛↛↛').shouldShow('456.78').shouldHaveCaretAt(0);
-      typing('123456.78⇤↛↛↛↛').shouldShow('56.78').shouldHaveCaretAt(0);
-      typing('123456.78⇤↛↛↛↛↛').shouldShow('6.78').shouldHaveCaretAt(0);
-      typing('123456.78⇤↛↛↛↛↛↛').shouldShow('.78').shouldHaveCaretAt(0);
-      typing('123456.78⇤↛↛↛↛↛↛↛').shouldShow('78').shouldHaveCaretAt(0);
-      typing('123456.78⇤↛↛↛↛↛↛↛↛').shouldShow('8').shouldHaveCaretAt(0);
-      typing('123456.78⇤↛↛↛↛↛↛↛↛↛').shouldShow('').shouldHaveCaretAt(0);
+      test().typing('123456.78⇤↛').shouldShow('23,456.78').shouldHaveCaretAt(0);
+      test().typing('123456.78⇤↛↛').shouldShow('3,456.78').shouldHaveCaretAt(0);
+      test().typing('123456.78⇤↛↛↛').shouldShow('456.78').shouldHaveCaretAt(0);
+      test().typing('123456.78⇤↛↛↛↛').shouldShow('56.78').shouldHaveCaretAt(0);
+      test().typing('123456.78⇤↛↛↛↛↛').shouldShow('6.78').shouldHaveCaretAt(0);
+      test().typing('123456.78⇤↛↛↛↛↛↛').shouldShow('.78').shouldHaveCaretAt(0);
+      test().typing('123456.78⇤↛↛↛↛↛↛↛').shouldShow('78').shouldHaveCaretAt(0);
+      test().typing('123456.78⇤↛↛↛↛↛↛↛↛').shouldShow('8').shouldHaveCaretAt(0);
+      test().typing('123456.78⇤↛↛↛↛↛↛↛↛↛').shouldShow('').shouldHaveCaretAt(0);
 
-      typing('123456.78←↛').shouldShow('123,456.7').shouldHaveCaretAt(9);
-      typing('123456.78←←↛').shouldShow('123,456.8').shouldHaveCaretAt(8);
-      typing('123456.78←←←←↛').shouldShow('12,345.78').shouldHaveCaretAt(6);
-      typing('123456.78←←←←←↛').shouldShow('12,346.78').shouldHaveCaretAt(5);
+      test().typing('123456.78←↛').shouldShow('123,456.7').shouldHaveCaretAt(9);
+      test().typing('123456.78←←↛').shouldShow('123,456.8').shouldHaveCaretAt(8);
+      test().typing('123456.78←←←←↛').shouldShow('12,345.78').shouldHaveCaretAt(6);
+      test().typing('123456.78←←←←←↛').shouldShow('12,346.78').shouldHaveCaretAt(5);
     });
   });
 
   describe('traverses thousands delimiter', () => {
     describe('backwards one place if BACKSPACE is pressed when caret is positioned directly ahead of it', () => {
-      typing('123456←←←↚').shouldShow('123,456').shouldHaveCaretAt(3);
+      test().typing('123456←←←↚').shouldShow('123,456').shouldHaveCaretAt(3);
     });
 
     describe('forwards one place if DELETE is pressed when caret is positioned directly behind of it', () => {
-      typing('123456←←←←↛').shouldShow('123,456').shouldHaveCaretAt(4);
+      test().typing('123456←←←←↛').shouldShow('123,456').shouldHaveCaretAt(4);
     });
   });
 
   describe('deletes decimal delimiter', () => {
     describe('when BACKSPACE is pressed while caret is positioned directly ahead of it', () => {
-      typing('123456.78←←↚').shouldShow('12,345,678').shouldHaveCaretAt(8);
-      typing('123456.78←←↚.↚').shouldShow('12,345,678').shouldHaveCaretAt(8);
+      test().typing('123456.78←←↚').shouldShow('12,345,678').shouldHaveCaretAt(8);
+      test().typing('123456.78←←↚.↚').shouldShow('12,345,678').shouldHaveCaretAt(8);
     });
 
     describe('when DELETE is pressed while caret is positioned directly behind of it', () => {
-      typing('123456.78←←←↛').shouldShow('12,345,678').shouldHaveCaretAt(8);
-      typing('123456.78←←←↛.←↛').shouldShow('12,345,678').shouldHaveCaretAt(8);
+      test().typing('123456.78←←←↛').shouldShow('12,345,678').shouldHaveCaretAt(8);
+      test().typing('123456.78←←←↛.←↛').shouldShow('12,345,678').shouldHaveCaretAt(8);
     });
   })
 });

--- a/test/specs/formatting-decimals.js
+++ b/test/specs/formatting-decimals.js
@@ -1,65 +1,91 @@
-import {load, finputReversedDelimiters, finputDefaultDelimiters} from '../pageObjects/index';
-import customCommandsFactory from '../customCommands';
+import { load, unload } from '../pageObjects/index';
+import { getDriver } from '../helpers';
+import createCommands from '../customCommands';
 
 describe('formatting decimals', () => {
-  beforeAll(load);
+  let driver;
+  let finputDefaultDelimiters;
+  let finputReversedDelimiters;
+  let nativeText;
 
+  const test = createCommands();
+
+  beforeAll(async () => {
+    driver = getDriver();
+    ({ 
+      finputDefaultDelimiters,
+      finputReversedDelimiters,
+      nativeText
+    } = await load(driver));
+  });
 
   describe('default delimiters', () => {
-    const {typing} = customCommandsFactory(finputDefaultDelimiters);
+    beforeAll(async () => {
+      test.withEnvironment({
+        driver,
+        finputElement: finputDefaultDelimiters,
+        nativeText
+      });
+    });
 
     describe('while focused', () => {
-      typing(`0`).shouldShow(`0`);
-      typing(`10`).shouldShow(`10`);
-      typing(`1←0`).shouldShow(`1`);
-      typing(`0.5←0`).shouldShow(`0.05`);
-      typing(`0.5←0`).shouldShow(`0.05`);
-      typing(`0.5←←0`).shouldShow(`0.5`);
-      typing(`1.5←←0`).shouldShow(`10.5`);
-      typing(`0.5←←7`).shouldShow(`7.5`);
-      typing(`0.5←←←0`).shouldShow(`0.5`);
-      typing(`.8`).shouldShow(`.8`);
-      typing(`.8←0`).shouldShow(`.08`);
-      typing(`.8←←0`).shouldShow(`0.8`);
-      typing(`123456←←←←←.`).shouldShow(`12.34`);
-      typing(`12.345`).shouldShow(`12.34`);
-      typing(`12.34←←↚`).shouldShow(`1,234`);
-      typing(`12.34←←↚`).shouldShow(`1,234`);
+      test().typing(`0`).shouldShow(`0`);
+      test().typing(`10`).shouldShow(`10`);
+      test().typing(`1←0`).shouldShow(`1`);
+      test().typing(`0.5←0`).shouldShow(`0.05`);
+      test().typing(`0.5←0`).shouldShow(`0.05`);
+      test().typing(`0.5←←0`).shouldShow(`0.5`);
+      test().typing(`1.5←←0`).shouldShow(`10.5`);
+      test().typing(`0.5←←7`).shouldShow(`7.5`);
+      test().typing(`0.5←←←0`).shouldShow(`0.5`);
+      test().typing(`.8`).shouldShow(`.8`);
+      test().typing(`.8←0`).shouldShow(`.08`);
+      test().typing(`.8←←0`).shouldShow(`0.8`);
+      test().typing(`123456←←←←←.`).shouldShow(`12.34`);
+      test().typing(`12.345`).shouldShow(`12.34`);
+      test().typing(`12.34←←↚`).shouldShow(`1,234`);
+      test().typing(`12.34←←↚`).shouldShow(`1,234`);
     });
 
     describe('on blur', () => {
-      typing(`0.8`).thenBlurring().shouldShow(`0.80`);
-      typing(`.8`).thenBlurring().shouldShow(`0.80`);
-      typing(`8.88`).thenBlurring().shouldShow(`8.88`);
+      test().typing(`0.8`).thenBlurring().shouldShow(`0.80`);
+      test().typing(`.8`).thenBlurring().shouldShow(`0.80`);
+      test().typing(`8.88`).thenBlurring().shouldShow(`8.88`);
     });
   });
 
   describe('reversed delimiters', () => {
-    const {typing} = customCommandsFactory(finputReversedDelimiters);
+    beforeAll(async () => {
+      test.withEnvironment({
+        driver,
+        finputElement: finputReversedDelimiters,
+        nativeText
+      });
+    });
 
     describe('while focused', () => {
-      typing(`0`).shouldShow(`0`);
-      typing(`10`).shouldShow(`10`);
-      typing(`1←0`).shouldShow(`1`);
-      typing(`0,5←0`).shouldShow(`0,05`);
-      typing(`0,5←0`).shouldShow(`0,05`);
-      typing(`0,5←←0`).shouldShow(`0,5`);
-      typing(`1,5←←0`).shouldShow(`10,5`);
-      typing(`0,5←←7`).shouldShow(`7,5`);
-      typing(`0,5←←←0`).shouldShow(`0,5`);
-      typing(`,8`).shouldShow(`,8`);
-      typing(`,8←0`).shouldShow(`,08`);
-      typing(`,8←←0`).shouldShow(`0,8`);
-      typing(`123456←←←←←,`).shouldShow(`12,34`);
-      typing(`12,345`).shouldShow(`12,34`);
-      typing(`12,34←←↚`).shouldShow(`1.234`);
-      typing(`12,34←←↚`).shouldShow(`1.234`);
+      test().typing(`0`).shouldShow(`0`);
+      test().typing(`10`).shouldShow(`10`);
+      test().typing(`1←0`).shouldShow(`1`);
+      test().typing(`0,5←0`).shouldShow(`0,05`);
+      test().typing(`0,5←0`).shouldShow(`0,05`);
+      test().typing(`0,5←←0`).shouldShow(`0,5`);
+      test().typing(`1,5←←0`).shouldShow(`10,5`);
+      test().typing(`0,5←←7`).shouldShow(`7,5`);
+      test().typing(`0,5←←←0`).shouldShow(`0,5`);
+      test().typing(`,8`).shouldShow(`,8`);
+      test().typing(`,8←0`).shouldShow(`,08`);
+      test().typing(`,8←←0`).shouldShow(`0,8`);
+      test().typing(`123456←←←←←,`).shouldShow(`12,34`);
+      test().typing(`12,345`).shouldShow(`12,34`);
+      test().typing(`12,34←←↚`).shouldShow(`1.234`);
+      test().typing(`12,34←←↚`).shouldShow(`1.234`);
     });
 
     describe('on blur', () => {
-      typing(`0,8`).thenBlurring().shouldShow(`0,80`);
-      typing(`,8`).thenBlurring().shouldShow(`0,80`);
-      typing(`8,88`).thenBlurring().shouldShow(`8,88`);
+      test().typing(`0,8`).thenBlurring().shouldShow(`0,80`);
+      test().typing(`,8`).thenBlurring().shouldShow(`0,80`);
+      test().typing(`8,88`).thenBlurring().shouldShow(`8,88`);
     })
   });
 

--- a/test/specs/formatting-negatives.js
+++ b/test/specs/formatting-negatives.js
@@ -1,55 +1,83 @@
-import {load, finputReversedDelimiters, finputDefaultDelimiters} from '../pageObjects/index';
-import customCommandsFactory from '../customCommands';
+import { load, unload } from '../pageObjects/index';
+import { getDriver } from '../helpers';
+import createCommands from '../customCommands';
 
 describe('formatting negatives', () => {
-  beforeAll(load);
+  let driver;
+  let finputDefaultDelimiters;
+  let finputReversedDelimiters;
+  let nativeText;
 
+  const test = createCommands();
+
+  beforeAll(async () => {
+    driver = getDriver();
+    ({
+      finputDefaultDelimiters,
+      finputReversedDelimiters,
+      nativeText
+    } = await load(driver));
+  });
+
+  afterAll(async () => await unload(driver));
 
   describe('default delimiters', () => {
-    const {typing} = customCommandsFactory(finputDefaultDelimiters);
+    beforeAll(async () => {
+      test.withEnvironment({
+        driver,
+        finputElement: finputDefaultDelimiters,
+        nativeText
+      });
+    });
 
     describe('while focused', () => {
-      typing(`-`).shouldShow(`-`);
-      typing(`-0`).shouldShow(`-0`);
-      typing(`--`).shouldShow(`-`);
-      typing(`-←0`).shouldShow(`-`);
-      typing(`0-`).shouldShow(`0`);
-      typing(`0-`).shouldShow(`0`);
-      typing(`-1000`).shouldShow(`-1,000`);
-      typing(`-1k`).shouldShow(`-1,000`);
+      test().typing(`-`).shouldShow(`-`);
+      test().typing(`-0`).shouldShow(`-0`);
+      test().typing(`--`).shouldShow(`-`);
+      test().typing(`-←0`).shouldShow(`-`);
+      test().typing(`0-`).shouldShow(`0`);
+      test().typing(`0-`).shouldShow(`0`);
+      test().typing(`-1000`).shouldShow(`-1,000`);
+      test().typing(`-1k`).shouldShow(`-1,000`);
     });
 
     describe('on blur', () => {
-      typing(`-.`).thenBlurring().shouldShow(`-0.00`);
-      typing(`-`).thenBlurring().shouldShow(`-0.00`);
-      typing(`-0`).thenBlurring().shouldShow(`-0.00`);
-      typing(`-0.`).thenBlurring().shouldShow(`-0.00`);
-      typing(`-.66`).thenBlurring().shouldShow(`-0.66`);
-      typing(`-1000`).thenBlurring().shouldShow(`-1,000.00`);
+      test().typing(`-.`).thenBlurring().shouldShow(`-0.00`);
+      test().typing(`-`).thenBlurring().shouldShow(`-0.00`);
+      test().typing(`-0`).thenBlurring().shouldShow(`-0.00`);
+      test().typing(`-0.`).thenBlurring().shouldShow(`-0.00`);
+      test().typing(`-.66`).thenBlurring().shouldShow(`-0.66`);
+      test().typing(`-1000`).thenBlurring().shouldShow(`-1,000.00`);
     });
   });
 
   describe('reversed delimiters', () => {
-    const {typing} = customCommandsFactory(finputReversedDelimiters);
+    beforeAll(async () => {
+      test.withEnvironment({
+        driver,
+        finputElement: finputReversedDelimiters,
+        nativeText
+      });
+    });
 
     describe('while focused', () => {
-      typing(`-`).shouldShow(`-`);
-      typing(`-0`).shouldShow(`-0`);
-      typing(`--`).shouldShow(`-`);
-      typing(`-←0`).shouldShow(`-`);
-      typing(`0-`).shouldShow(`0`);
-      typing(`0-`).shouldShow(`0`);
-      typing(`-1000`).shouldShow(`-1.000`);
-      typing(`-1k`).shouldShow(`-1.000`);
+      test().typing(`-`).shouldShow(`-`);
+      test().typing(`-0`).shouldShow(`-0`);
+      test().typing(`--`).shouldShow(`-`);
+      test().typing(`-←0`).shouldShow(`-`);
+      test().typing(`0-`).shouldShow(`0`);
+      test().typing(`0-`).shouldShow(`0`);
+      test().typing(`-1000`).shouldShow(`-1.000`);
+      test().typing(`-1k`).shouldShow(`-1.000`);
     });
 
     describe('on blur', () => {
-      typing(`-,`).thenBlurring().shouldShow(`-0,00`);
-      typing(`-`).thenBlurring().shouldShow(`-0,00`);
-      typing(`-0`).thenBlurring().shouldShow(`-0,00`);
-      typing(`-0,`).thenBlurring().shouldShow(`-0,00`);
-      typing(`-,66`).thenBlurring().shouldShow(`-0,66`);
-      typing(`-1000`).thenBlurring().shouldShow(`-1.000,00`);
+      test().typing(`-,`).thenBlurring().shouldShow(`-0,00`);
+      test().typing(`-`).thenBlurring().shouldShow(`-0,00`);
+      test().typing(`-0`).thenBlurring().shouldShow(`-0,00`);
+      test().typing(`-0,`).thenBlurring().shouldShow(`-0,00`);
+      test().typing(`-,66`).thenBlurring().shouldShow(`-0,66`);
+      test().typing(`-1000`).thenBlurring().shouldShow(`-1.000,00`);
     });
   });
 

--- a/test/specs/modifiers.js
+++ b/test/specs/modifiers.js
@@ -1,28 +1,42 @@
-import {load, finputDefaultDelimiters} from '../pageObjects/index';
-import customCommandsFactory from '../customCommands';
-
-const {typing} = customCommandsFactory(finputDefaultDelimiters);
+import { load, unload } from '../pageObjects/index';
+import { getDriver } from '../helpers';
+import createCommands from '../customCommands';
 
 describe('modifiers', () => {
-  beforeAll(load);
+  let driver;
+  let finputDefaultDelimiters;
+
+  const test = createCommands();
+
+  beforeAll(async () => {
+    driver = getDriver();
+    ({ finputDefaultDelimiters } = await load(driver));
+
+    test.withEnvironment({
+      driver,
+      finputElement: finputDefaultDelimiters
+    });
+  });
+
+  afterAll(async () => await unload(driver));
 
   describe('are not blocked from activating keyboard shortcuts', () => {
     // TODO: find a way to test browser shortcuts blur the input (not currently working with chromedriver)
-    typing('k').whileModifierPressed().shouldShow('');
-    typing('m').whileModifierPressed().shouldShow('');
-    typing('b').whileModifierPressed().shouldShow('');
-    typing('l').whileModifierPressed().shouldShow('');
-    typing('h').whileModifierPressed().shouldShow('');
+    test().typing('k').whileModifierPressed().shouldShow('');
+    test().typing('m').whileModifierPressed().shouldShow('');
+    test().typing('b').whileModifierPressed().shouldShow('');
+    test().typing('l').whileModifierPressed().shouldShow('');
+    test().typing('h').whileModifierPressed().shouldShow('');
 
-    typing('0').whileModifierPressed().shouldShow('');
-    typing('1').whileModifierPressed().shouldShow('');
-    typing('2').whileModifierPressed().shouldShow('');
-    typing('3').whileModifierPressed().shouldShow('');
+    test().typing('0').whileModifierPressed().shouldShow('');
+    test().typing('1').whileModifierPressed().shouldShow('');
+    test().typing('2').whileModifierPressed().shouldShow('');
+    test().typing('3').whileModifierPressed().shouldShow('');
 
-    typing('-').whileModifierPressed().shouldShow('');
-    typing('+').whileModifierPressed().shouldShow('');
-    typing('.').whileModifierPressed().shouldShow('');
-    typing(',').whileModifierPressed().shouldShow('');
+    test().typing('-').whileModifierPressed().shouldShow('');
+    test().typing('+').whileModifierPressed().shouldShow('');
+    test().typing('.').whileModifierPressed().shouldShow('');
+    test().typing(',').whileModifierPressed().shouldShow('');
   });
 });
 ;

--- a/test/specs/shortcuts.js
+++ b/test/specs/shortcuts.js
@@ -1,130 +1,155 @@
-import {load, finputReversedDelimiters, finputDefaultDelimiters} from '../pageObjects/index';
-import customCommandsFactory from '../customCommands';
+import { load, unload } from '../pageObjects/index';
+import { getDriver } from '../helpers';
+import createCommands from '../customCommands';
 
 describe('shortcuts', () => {
-  beforeAll(load);
+  let driver;
+  let finputDefaultDelimiters;
+  let finputReversedDelimiters;
+
+  const test = createCommands();
+
+  beforeAll(async () => {
+    driver = getDriver();
+    ({ 
+      finputDefaultDelimiters,
+      finputReversedDelimiters
+    } = await load(driver));
+  });
+
+  afterAll(async () => await unload(driver));
 
   describe('default delimiters', () => {
-    const {typing} = customCommandsFactory(finputDefaultDelimiters);
+    beforeAll(async () => {
+      test.withEnvironment({
+        driver,
+        finputElement: finputDefaultDelimiters
+      });
+    });
 
     describe('typed into empty field', () => {
       // TODO: fix bug which causes shortcuts to be capped to a limit
       for (let i = 1; i <= 2; i++) {
-        typing(`k`.padEnd(i, `k`)).shouldShow(`1` + `,000`.padEnd(i * 4, `,000`));
-        typing(`m`.padEnd(i, `m`)).shouldShow(`1` + `,000`.padEnd(i * 8, `,000`));
-        typing(`b`.padEnd(i, `b`)).shouldShow(`1` + `,000`.padEnd(i * 12, `,000`));
+        test().typing(`k`.padEnd(i, `k`)).shouldShow(`1` + `,000`.padEnd(i * 4, `,000`));
+        test().typing(`m`.padEnd(i, `m`)).shouldShow(`1` + `,000`.padEnd(i * 8, `,000`));
+        test().typing(`b`.padEnd(i, `b`)).shouldShow(`1` + `,000`.padEnd(i * 12, `,000`));
       }
     });
 
     describe('entered onto end of integer number', () => {
-      typing(`1k`).shouldShow(`1,000`);
-      typing(`2m`).shouldShow(`2,000,000`);
-      typing(`3b`).shouldShow(`3,000,000,000`);
+      test().typing(`1k`).shouldShow(`1,000`);
+      test().typing(`2m`).shouldShow(`2,000,000`);
+      test().typing(`3b`).shouldShow(`3,000,000,000`);
 
-      typing(`1k1`).shouldShow(`10,001`);
-      typing(`2m2`).shouldShow(`20,000,002`);
-      typing(`3b3`).shouldShow(`30,000,000,003`);
+      test().typing(`1k1`).shouldShow(`10,001`);
+      test().typing(`2m2`).shouldShow(`20,000,002`);
+      test().typing(`3b3`).shouldShow(`30,000,000,003`);
 
-      typing(`1k1k`).shouldShow(`10,001,000`);
-      typing(`1m1m`).shouldShow(`10,000,001,000,000`);
-      typing(`1b1b`).shouldShow(`10,000,000,001,000,000,000`);
+      test().typing(`1k1k`).shouldShow(`10,001,000`);
+      test().typing(`1m1m`).shouldShow(`10,000,001,000,000`);
+      test().typing(`1b1b`).shouldShow(`10,000,000,001,000,000,000`);
     });
 
     describe('entered onto end of decimal number', () => {
-      typing('.1k').shouldShow('100');
-      typing('.1m').shouldShow('100,000');
-      typing('.1b').shouldShow('100,000,000');
+      test().typing('.1k').shouldShow('100');
+      test().typing('.1m').shouldShow('100,000');
+      test().typing('.1b').shouldShow('100,000,000');
 
-      typing('1.1k').shouldShow('1,100');
-      typing('1.1m').shouldShow('1,100,000');
-      typing('1.1b').shouldShow('1,100,000,000');
+      test().typing('1.1k').shouldShow('1,100');
+      test().typing('1.1m').shouldShow('1,100,000');
+      test().typing('1.1b').shouldShow('1,100,000,000');
 
-      typing('1.01k').shouldShow('1,010');
-      typing('1.01m').shouldShow('1,010,000');
-      typing('1.01b').shouldShow('1,010,000,000');
+      test().typing('1.01k').shouldShow('1,010');
+      test().typing('1.01m').shouldShow('1,010,000');
+      test().typing('1.01b').shouldShow('1,010,000,000');
     });
 
     describe('entered into middle of whole number', () => {
-      typing('12345←k').shouldShow('12,345,000');
-      typing('12345←m').shouldShow('12,345,000,000');
-      typing('12345←b').shouldShow('12,345,000,000,000');
+      test().typing('12345←k').shouldShow('12,345,000');
+      test().typing('12345←m').shouldShow('12,345,000,000');
+      test().typing('12345←b').shouldShow('12,345,000,000,000');
 
-      typing('12345←←k').shouldShow('12,345,000');
-      typing('12345←←m').shouldShow('12,345,000,000');
-      typing('12345←←b').shouldShow('12,345,000,000,000');
+      test().typing('12345←←k').shouldShow('12,345,000');
+      test().typing('12345←←m').shouldShow('12,345,000,000');
+      test().typing('12345←←b').shouldShow('12,345,000,000,000');
     });
 
     describe('combined', () => {
-      typing(`kb`).shouldShow(`1,000,000,000,000`);
-      typing(`bk`).shouldShow(`1,000,000,000,000`);
+      test().typing(`kb`).shouldShow(`1,000,000,000,000`);
+      test().typing(`bk`).shouldShow(`1,000,000,000,000`);
 
-      typing(`km`).shouldShow(`1,000,000,000`);
-      typing(`mk`).shouldShow(`1,000,000,000`);
+      test().typing(`km`).shouldShow(`1,000,000,000`);
+      test().typing(`mk`).shouldShow(`1,000,000,000`);
 
-      typing(`bm`).shouldShow(`1,000,000,000,000,000`);
-      typing(`mb`).shouldShow(`1,000,000,000,000,000`);
+      test().typing(`bm`).shouldShow(`1,000,000,000,000,000`);
+      test().typing(`mb`).shouldShow(`1,000,000,000,000,000`);
     });
   });
 
   describe('reversed delimiters', () => {
-    const {typing} = customCommandsFactory(finputReversedDelimiters);
+    beforeAll(async () => {
+      test.withEnvironment({
+        driver,
+        finputElement: finputReversedDelimiters
+      });
+    });
 
     test('typed into empty field', () => {
       // TODO: fix bug which causes shortcuts to be capped to a limit
       for (let i = 1; i <= 2; i++) {
-        typing(`k`.padEnd(i, `k`)).shouldShow(`1` + `.000`.padEnd(i * 4, `.000`));
-        typing(`m`.padEnd(i, `m`)).shouldShow(`1` + `.000`.padEnd(i * 8, `.000`));
-        typing(`b`.padEnd(i, `b`)).shouldShow(`1` + `.000`.padEnd(i * 12, `.000`));
+        test().typing(`k`.padEnd(i, `k`)).shouldShow(`1` + `.000`.padEnd(i * 4, `.000`));
+        test().typing(`m`.padEnd(i, `m`)).shouldShow(`1` + `.000`.padEnd(i * 8, `.000`));
+        test().typing(`b`.padEnd(i, `b`)).shouldShow(`1` + `.000`.padEnd(i * 12, `.000`));
       }
     });
 
     describe('entered onto end of integer number', () => {
-      typing(`1k`).shouldShow(`1.000`);
-      typing(`2m`).shouldShow(`2.000.000`);
-      typing(`3b`).shouldShow(`3.000.000.000`);
+      test().typing(`1k`).shouldShow(`1.000`);
+      test().typing(`2m`).shouldShow(`2.000.000`);
+      test().typing(`3b`).shouldShow(`3.000.000.000`);
 
-      typing(`1k1`).shouldShow(`10.001`);
-      typing(`2m2`).shouldShow(`20.000.002`);
-      typing(`3b3`).shouldShow(`30.000.000.003`);
+      test().typing(`1k1`).shouldShow(`10.001`);
+      test().typing(`2m2`).shouldShow(`20.000.002`);
+      test().typing(`3b3`).shouldShow(`30.000.000.003`);
 
-      typing(`1k1k`).shouldShow(`10.001.000`);
-      typing(`1m1m`).shouldShow(`10.000.001.000.000`);
-      typing(`1b1b`).shouldShow(`10.000.000.001.000.000.000`);
+      test().typing(`1k1k`).shouldShow(`10.001.000`);
+      test().typing(`1m1m`).shouldShow(`10.000.001.000.000`);
+      test().typing(`1b1b`).shouldShow(`10.000.000.001.000.000.000`);
     });
 
     describe('entered onto end of decimal number', () => {
-      typing(',1k').shouldShow('100');
-      typing(',1m').shouldShow('100.000');
-      typing(',1b').shouldShow('100.000.000');
+      test().typing(',1k').shouldShow('100');
+      test().typing(',1m').shouldShow('100.000');
+      test().typing(',1b').shouldShow('100.000.000');
 
-      typing('1,1k').shouldShow('1.100');
-      typing('1,1m').shouldShow('1.100.000');
-      typing('1,1b').shouldShow('1.100.000.000');
+      test().typing('1,1k').shouldShow('1.100');
+      test().typing('1,1m').shouldShow('1.100.000');
+      test().typing('1,1b').shouldShow('1.100.000.000');
 
-      typing('1,01k').shouldShow('1.010');
-      typing('1,01m').shouldShow('1.010.000');
-      typing('1,01b').shouldShow('1.010.000.000');
+      test().typing('1,01k').shouldShow('1.010');
+      test().typing('1,01m').shouldShow('1.010.000');
+      test().typing('1,01b').shouldShow('1.010.000.000');
     });
 
     describe('entered into middle of whole number', () => {
-      typing('12345←k').shouldShow('12.345.000');
-      typing('12345←m').shouldShow('12.345.000.000');
-      typing('12345←b').shouldShow('12.345.000.000.000');
+      test().typing('12345←k').shouldShow('12.345.000');
+      test().typing('12345←m').shouldShow('12.345.000.000');
+      test().typing('12345←b').shouldShow('12.345.000.000.000');
 
-      typing('12345←←k').shouldShow('12.345.000');
-      typing('12345←←m').shouldShow('12.345.000.000');
-      typing('12345←←b').shouldShow('12.345.000.000.000');
+      test().typing('12345←←k').shouldShow('12.345.000');
+      test().typing('12345←←m').shouldShow('12.345.000.000');
+      test().typing('12345←←b').shouldShow('12.345.000.000.000');
     });
 
     describe('combined', () => {
-      typing(`kb`).shouldShow(`1.000.000.000.000`);
-      typing(`bk`).shouldShow(`1.000.000.000.000`);
+      test().typing(`kb`).shouldShow(`1.000.000.000.000`);
+      test().typing(`bk`).shouldShow(`1.000.000.000.000`);
 
-      typing(`km`).shouldShow(`1.000.000.000`);
-      typing(`mk`).shouldShow(`1.000.000.000`);
+      test().typing(`km`).shouldShow(`1.000.000.000`);
+      test().typing(`mk`).shouldShow(`1.000.000.000`);
 
-      typing(`bm`).shouldShow(`1.000.000.000.000.000`);
-      typing(`mb`).shouldShow(`1.000.000.000.000.000`);
+      test().typing(`bm`).shouldShow(`1.000.000.000.000.000`);
+      test().typing(`mb`).shouldShow(`1.000.000.000.000.000`);
     });
   });
 });

--- a/test/specs/switching-delimiters.js
+++ b/test/specs/switching-delimiters.js
@@ -1,52 +1,71 @@
-import { load, finputSwitchOptions } from '../pageObjects/index';
-import customCommandsFactory from '../customCommands';
-
-const { typing } = customCommandsFactory(finputSwitchOptions);
+import { load, unload } from '../pageObjects/index';
+import { getDriver } from '../helpers';
+import createCommands from '../customCommands';
 
 describe('Switching delimiters', () => {
-  beforeAll(load);
+  let driver;
+  let finputSwitchOptions;
+  let finputSwitchOptionsButton;
+
+  const test = createCommands();
+
+  beforeAll(async () => {
+    driver = getDriver();
+    ({
+      finputSwitchOptions, 
+      finputSwitchOptionsButton
+    } = await load(driver));
+
+    test.withEnvironment({
+      driver,
+      finputElement: finputSwitchOptions, 
+      finputSwitchOptionsButton 
+    });
+  });
+
+  afterAll(async () => await unload(driver));
 
   // only decimal
-  typing('.99').thenSwitchingDelimiters().shouldShow('0,99');
-  typing(',99').thenSwitchingDelimiters().shouldShow('0.99');
-  typing('.99').thenSwitchingDelimiters().shouldShow('0,99');
-  typing(',99').thenSwitchingDelimiters().shouldShow('0.99');
+  test().typing('.99').thenSwitchingDelimiters().shouldShow('0,99');
+  test().typing(',99').thenSwitchingDelimiters().shouldShow('0.99');
+  test().typing('.99').thenSwitchingDelimiters().shouldShow('0,99');
+  test().typing(',99').thenSwitchingDelimiters().shouldShow('0.99');
 
-  typing('-.99').thenSwitchingDelimiters().shouldShow('-0,99');
-  typing('-,99').thenSwitchingDelimiters().shouldShow('-0.99');
-  typing('-.99').thenSwitchingDelimiters().shouldShow('-0,99');
-  typing('-,99').thenSwitchingDelimiters().shouldShow('-0.99');
+  test().typing('-.99').thenSwitchingDelimiters().shouldShow('-0,99');
+  test().typing('-,99').thenSwitchingDelimiters().shouldShow('-0.99');
+  test().typing('-.99').thenSwitchingDelimiters().shouldShow('-0,99');
+  test().typing('-,99').thenSwitchingDelimiters().shouldShow('-0.99');
 
   // only thousands
-  typing('1k').thenSwitchingDelimiters().shouldShow('1.000,00');
-  typing('1k').thenSwitchingDelimiters().shouldShow('1,000.00');
-  typing('1k').thenSwitchingDelimiters().shouldShow('1.000,00');
-  typing('1k').thenSwitchingDelimiters().shouldShow('1,000.00');
+  test().typing('1k').thenSwitchingDelimiters().shouldShow('1.000,00');
+  test().typing('1k').thenSwitchingDelimiters().shouldShow('1,000.00');
+  test().typing('1k').thenSwitchingDelimiters().shouldShow('1.000,00');
+  test().typing('1k').thenSwitchingDelimiters().shouldShow('1,000.00');
 
-  typing('-1k').thenSwitchingDelimiters().shouldShow('-1.000,00');
-  typing('-1k').thenSwitchingDelimiters().shouldShow('-1,000.00');
-  typing('-1k').thenSwitchingDelimiters().shouldShow('-1.000,00');
-  typing('-1k').thenSwitchingDelimiters().shouldShow('-1,000.00');
+  test().typing('-1k').thenSwitchingDelimiters().shouldShow('-1.000,00');
+  test().typing('-1k').thenSwitchingDelimiters().shouldShow('-1,000.00');
+  test().typing('-1k').thenSwitchingDelimiters().shouldShow('-1.000,00');
+  test().typing('-1k').thenSwitchingDelimiters().shouldShow('-1,000.00');
 
   // thousands and decimals
-  typing('123456.78').thenSwitchingDelimiters().shouldShow('123.456,78');
-  typing('123456,78').thenSwitchingDelimiters().shouldShow('123,456.78');
-  typing('123456.78').thenSwitchingDelimiters().shouldShow('123.456,78');
-  typing('123456,78').thenSwitchingDelimiters().shouldShow('123,456.78');
+  test().typing('123456.78').thenSwitchingDelimiters().shouldShow('123.456,78');
+  test().typing('123456,78').thenSwitchingDelimiters().shouldShow('123,456.78');
+  test().typing('123456.78').thenSwitchingDelimiters().shouldShow('123.456,78');
+  test().typing('123456,78').thenSwitchingDelimiters().shouldShow('123,456.78');
 
-  typing('-123456.78').thenSwitchingDelimiters().shouldShow('-123.456,78');
-  typing('-123456,78').thenSwitchingDelimiters().shouldShow('-123,456.78');
-  typing('-123456.78').thenSwitchingDelimiters().shouldShow('-123.456,78');
-  typing('-123456,78').thenSwitchingDelimiters().shouldShow('-123,456.78');
+  test().typing('-123456.78').thenSwitchingDelimiters().shouldShow('-123.456,78');
+  test().typing('-123456,78').thenSwitchingDelimiters().shouldShow('-123,456.78');
+  test().typing('-123456.78').thenSwitchingDelimiters().shouldShow('-123.456,78');
+  test().typing('-123456,78').thenSwitchingDelimiters().shouldShow('-123,456.78');
 
   // many thousands
-  typing('1b.99').thenSwitchingDelimiters().shouldShow('1.000.000.000,99');
-  typing('1b,99').thenSwitchingDelimiters().shouldShow('1,000,000,000.99');
-  typing('1b.99').thenSwitchingDelimiters().shouldShow('1.000.000.000,99');
-  typing('1b,99').thenSwitchingDelimiters().shouldShow('1,000,000,000.99');
+  test().typing('1b.99').thenSwitchingDelimiters().shouldShow('1.000.000.000,99');
+  test().typing('1b,99').thenSwitchingDelimiters().shouldShow('1,000,000,000.99');
+  test().typing('1b.99').thenSwitchingDelimiters().shouldShow('1.000.000.000,99');
+  test().typing('1b,99').thenSwitchingDelimiters().shouldShow('1,000,000,000.99');
 
-  typing('-1b.99').thenSwitchingDelimiters().shouldShow('-1.000.000.000,99');
-  typing('-1b,99').thenSwitchingDelimiters().shouldShow('-1,000,000,000.99');
-  typing('-1b.99').thenSwitchingDelimiters().shouldShow('-1.000.000.000,99');
-  typing('-1b,99').thenSwitchingDelimiters().shouldShow('-1,000,000,000.99');
+  test().typing('-1b.99').thenSwitchingDelimiters().shouldShow('-1.000.000.000,99');
+  test().typing('-1b,99').thenSwitchingDelimiters().shouldShow('-1,000,000,000.99');
+  test().typing('-1b.99').thenSwitchingDelimiters().shouldShow('-1.000.000.000,99');
+  test().typing('-1b,99').thenSwitchingDelimiters().shouldShow('-1,000,000,000.99');
 });

--- a/test/specs/traversals.js
+++ b/test/specs/traversals.js
@@ -1,28 +1,42 @@
-import {load, finputDefaultDelimiters} from '../pageObjects/index';
-import customCommandsFactory from '../customCommands';
-
-const {typing} = customCommandsFactory(finputDefaultDelimiters);
+import { load, unload } from '../pageObjects/index';
+import { getDriver } from '../helpers';
+import createCommands from '../customCommands';
 
 describe('traversals', () => {
-  beforeAll(load);
+  let driver;
+  let finputDefaultDelimiters;
+
+  const test = createCommands();
+
+  beforeAll(async () => {
+    driver = getDriver();
+    ({ finputDefaultDelimiters } = await load(driver));
+    
+    test.withEnvironment({
+      driver,
+      finputElement: finputDefaultDelimiters
+    });
+  });
+
+  afterAll(async () => await unload(driver));
 
   describe('supports HOME and END keys sending caret to start / end of field', () => {
-    typing(`12⇤3`).shouldShow(`312`).shouldHaveFocus(true).shouldHaveCaretAt(1);
-    typing(`123⇤⇤4`).shouldShow(`4,123`).shouldHaveCaretAt(1);
-    typing(`123⇤⇥4`).shouldShow(`1,234`).shouldHaveCaretAt(5);
-    typing(`123⇤⇥4⇤5`).shouldShow(`51,234`).shouldHaveCaretAt(1);
+    test().typing(`12⇤3`).shouldShow(`312`).shouldHaveFocus(true).shouldHaveCaretAt(1);
+    test().typing(`123⇤⇤4`).shouldShow(`4,123`).shouldHaveCaretAt(1);
+    test().typing(`123⇤⇥4`).shouldShow(`1,234`).shouldHaveCaretAt(5);
+    test().typing(`123⇤⇥4⇤5`).shouldShow(`51,234`).shouldHaveCaretAt(1);
   });
 
   describe('supports left and right ARROW keys shifting caret left / right one caret', () => {
-    typing(`123456←8`).shouldShow(`1,234,586`);
-    typing(`123456←←8`).shouldShow(`1,234,856`);
-    typing(`123456←←←8`).shouldShow(`1,238,456`);
+    test().typing(`123456←8`).shouldShow(`1,234,586`);
+    test().typing(`123456←←8`).shouldShow(`1,234,856`);
+    test().typing(`123456←←←8`).shouldShow(`1,238,456`);
   });
 
   describe('supports up and down ARROW keys sending caret to start / end of field', () => {
-    typing(`12↑3`).shouldShow(`312`).shouldHaveFocus(true).shouldHaveCaretAt(1);
-    typing(`123↑↑4`).shouldShow(`4,123`).shouldHaveCaretAt(1);
-    typing(`123↑↓4`).shouldShow(`1,234`).shouldHaveCaretAt(5);
-    typing(`123↑↓4↑5`).shouldShow(`51,234`).shouldHaveCaretAt(1);
+    test().typing(`12↑3`).shouldShow(`312`).shouldHaveFocus(true).shouldHaveCaretAt(1);
+    test().typing(`123↑↑4`).shouldShow(`4,123`).shouldHaveCaretAt(1);
+    test().typing(`123↑↓4`).shouldShow(`1,234`).shouldHaveCaretAt(5);
+    test().typing(`123↑↓4↑5`).shouldShow(`51,234`).shouldHaveCaretAt(1);
   });
 });


### PR DESCRIPTION
This is a first attempt to have tests in a bdd style with an environment injected at will (like in the beforeAll / beforeEach hooks).
Some commands are tagged as "setup". At the moment it is assumed that there is only one "not setup" command per test, but this can change in the future. This will need refactoring, as a setup command will become a "setup" for the closest previous "not setup" command.