### PR TITLE
Reset value to '' and rawValue to undefined when input is cleared

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,10 +111,6 @@ as follows:
 **Formatted value** - `element.value` _(the normal input value)_  
 **Raw numeric value** - `element.rawValue`
 
-
-This function removes all the event listeners, making the input behaviour like the default browser
-input once again.
-
 API
 --------------------
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -184,6 +184,7 @@ exports.allowedZero = function(val, char, caretPos, options) {
  */
 exports.formattedToRaw = function(formattedValue, options) {
   if (is.not.string(formattedValue)) return NaN;
+  if (!formattedValue.length) return undefined;
 
   // Number(...) accepts thousands ',' or '' and decimal '.' so we must:
 

--- a/test/unit/setRawValue.js
+++ b/test/unit/setRawValue.js
@@ -19,4 +19,17 @@ describe('setRawValue', () => {
         expect(element.value).toBe('0.00');
     });
 
+    it('has an initial value of empty string and rawValue of undefined', () => {
+        expect(element.value).toBe('');
+        expect(element.rawValue).toBe(undefined);
+    });
+
+    it('sets value to empty string and rawValue to 0 when entry is deleted', () => {
+        element.setRawValue(100);
+        element.setRawValue('');
+
+        expect(element.value).toBe('');
+        expect(element.rawValue).toBe(0);
+    });
+
 });

--- a/test/unit/setRawValue.js
+++ b/test/unit/setRawValue.js
@@ -24,12 +24,12 @@ describe('setRawValue', () => {
         expect(element.rawValue).toBe(undefined);
     });
 
-    it('sets value to empty string and rawValue to 0 when entry is deleted', () => {
+    it('resets back to empty string and undefined when entry is deleted', () => {
         element.setRawValue(100);
         element.setRawValue('');
 
         expect(element.value).toBe('');
-        expect(element.rawValue).toBe(0);
+        expect(element.rawValue).toBe(undefined);
     });
 
 });


### PR DESCRIPTION
When finput is initalised , before entry:
`element.value === ''` 
and 
`element.rawValue === undefined`

This state is now matched when all input is deleted.